### PR TITLE
Actually fetch and parse the error body responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "podman-autogen-api"]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/blazzy/podman-rest-client"
@@ -27,7 +27,7 @@ http = "1.1.0"
 hyper = { workspace = true }
 hyper-util = { version = "0.1.5", features = ["client-legacy", "http1"] }
 nix = { version = "0.29.0", features = ["user"] }
-podman-autogen-api = { version = "=0.6.0", path="podman-autogen-api" }
+podman-autogen-api = { version = "=0.7.0", path="podman-autogen-api" }
 russh = "0.43.0"
 russh-keys = "0.43.0"
 serde = { version = "1.0.203", features = ["derive"] }

--- a/podman-autogen-api/Cargo.toml
+++ b/podman-autogen-api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "podman-autogen-api"
 description = "Podman REST API client generated from the official swagger file using openapi-generator"
 readme = "README.md"
-version = "0.6.0"
+version = "0.7.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,65 @@
+use podman_rest_client::models::SpecGenerator;
+use podman_rest_client::models::VolumeCreateOptions;
+use podman_rest_client::PodmanRestClient;
+
+pub async fn pull_nginx_image(client: &PodmanRestClient) {
+    client
+        .images_api()
+        .image_pull_libpod(
+            Some("docker.io/library/nginx:latest"),
+            Some(true),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("Failed to pull image");
+}
+
+pub async fn create_nginx_container(client: &PodmanRestClient, container_name: &str) {
+    let create = SpecGenerator {
+        name: Some(container_name.into()),
+        image: Some("docker.io/library/nginx:latest".into()),
+        ..podman_rest_client::models::SpecGenerator::default()
+    };
+
+    client
+        .containers_api()
+        .container_create_libpod(create)
+        .await
+        .expect("Failed to create contaienr");
+}
+
+pub async fn delete_container(client: &PodmanRestClient, container_name: &str) {
+    client
+        .containers_api()
+        .container_delete_libpod(container_name, None, None, None, None, None)
+        .await
+        .expect("Failed to clean up container");
+}
+
+pub async fn create_volume(client: &PodmanRestClient, volume_name: &str) {
+    let create = VolumeCreateOptions {
+        name: Some(volume_name.into()),
+        ..VolumeCreateOptions::default()
+    };
+
+    client
+        .volumes_api()
+        .volume_create_libpod(Some(create))
+        .await
+        .expect("Failed to create a volume");
+}
+
+pub async fn delete_volume(client: &PodmanRestClient, volume_name: &str) {
+    client
+        .volumes_api()
+        .volume_delete_libpod(volume_name, None)
+        .await
+        .expect("Failed to clean up volume");
+}


### PR DESCRIPTION
The errors with just Body::Incoming were completely unhelpful. Actually parsing the error bodies is incredibly helpful.

Also disabling two tests that fail in CI. One because there is a bug in the podman spec. And another because the podman version in the ubuntu runner is too old for us.