### PR TITLE
Fix issue with volume mounts.

### DIFF
--- a/podman-autogen-api/src/models/mount.rs
+++ b/podman-autogen-api/src/models/mount.rs
@@ -24,8 +24,8 @@ pub struct Mount {
     /// Source specifies the name of the mount. Depending on mount type, this may be a volume name or a host path, or even ignored. Source is not supported for tmpfs (must be an empty value)
     #[serde(rename = "Source", skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    #[serde(rename = "Target", skip_serializing_if = "Option::is_none")]
-    pub target: Option<String>,
+    #[serde(rename = "Destination", skip_serializing_if = "Option::is_none")]
+    pub destination: Option<String>,
     #[serde(rename = "TmpfsOptions", skip_serializing_if = "Option::is_none")]
     pub tmpfs_options: Option<Box<models::TmpfsOptions>>,
     #[serde(rename = "Type", skip_serializing_if = "Option::is_none")]
@@ -42,7 +42,7 @@ impl Mount {
             consistency: None,
             read_only: None,
             source: None,
-            target: None,
+            destination: None,
             tmpfs_options: None,
             r#type: None,
             volume_options: None,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -100,7 +100,6 @@ async fn it_can_create_a_container() {
     common::delete_container(&client, "podman_rest_client_creation_test").await;
 }
 
-#[ignore = "Spec seems to broken. Possible related issue: https://github.com/containers/podman/issues/13092"]
 #[tokio::test]
 async fn it_can_create_a_container_with_a_volume_mounted() {
     let config = Config::guess().await.unwrap();
@@ -114,7 +113,7 @@ async fn it_can_create_a_container_with_a_volume_mounted() {
         image: Some("docker.io/library/nginx:latest".into()),
         mounts: Some(vec![models::Mount {
             source: Some("podman_rest_client_container_volume_test".into()),
-            target: Some("/foo".into()),
+            destination: Some("/my-volume".into()),
             ..models::Mount::default()
         }]),
         ..models::SpecGenerator::default()


### PR DESCRIPTION
The swagger spec has the wrong field for the target mount point. We have to hand fix the model here.

Closes: https://github.com/blazzy/podman-rest-client/issues/9