### PR TITLE
Fix parse error on pod deletion response

### DIFF
--- a/podman-autogen-api/src/models/pod_rm_report.rs
+++ b/podman-autogen-api/src/models/pod_rm_report.rs
@@ -18,7 +18,7 @@ pub struct PodRmReport {
     #[serde(rename = "Id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     #[serde(rename = "RemovedCtrs", skip_serializing_if = "Option::is_none")]
-    pub removed_ctrs: Option<std::collections::HashMap<String, String>>,
+    pub removed_ctrs: Option<std::collections::HashMap<String, Option<String>>>,
 }
 
 impl PodRmReport {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -43,6 +43,14 @@ pub async fn delete_container(client: &PodmanRestClient, container_name: &str) {
         .expect("Failed to clean up container");
 }
 
+pub async fn delete_pod(client: &PodmanRestClient, pod_name: &str) {
+    client
+        .pods_api()
+        .pod_delete_libpod(pod_name, None)
+        .await
+        .expect("Failed to clean up pod");
+}
+
 pub async fn create_volume(client: &PodmanRestClient, volume_name: &str) {
     let create = VolumeCreateOptions {
         name: Some(volume_name.into()),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -141,9 +141,28 @@ async fn it_can_inspect_a_container() {
         .containers_api()
         .container_inspect_libpod("podman_rest_client_inspect_test", None)
         .await
-        .expect("Failed to inspect pod");
+        .expect("Failed to inspect container");
 
     common::delete_container(&client, "podman_rest_client_inspect_test").await;
+}
+
+#[tokio::test]
+async fn it_can_create_a_pod() {
+    let config = Config::guess().await.unwrap();
+    let client = PodmanRestClient::new(config).await.unwrap();
+
+    let create = models::PodSpecGenerator {
+        name: Some("podman_rest_client_create_pod_test".into()),
+        ..models::PodSpecGenerator::default()
+    };
+
+    client
+        .pods_api()
+        .pod_create_libpod(Some(create))
+        .await
+        .expect("Failed to create pod");
+
+    common::delete_pod(&client, "podman_rest_client_create_pod_test").await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
Another spot where the swagger spec is wrong. The `removed_ctrs` HashMap in the delete pod response can sometime have null values instead of String.

Closes: https://github.com/blazzy/podman-rest-client/issues/13