### PR TITLE
Doc build fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
 
     - name: build docs
-      run: RUSTDOCFLAGS="--cfg docsrs" cargo doc
+      run: RUSTDOCFLAGS="--cfg docsrs" cargo doc --all-features
 
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ env:
 
 jobs:
   doc-build:
+    runs-on: ubuntu-24.04
+    steps:
     - uses: dtolnay/rust-toolchain@nightly
 
     - name: build docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
   doc-build:
     runs-on: ubuntu-24.04
     steps:
+    - uses: actions/checkout@v4
+
     - uses: dtolnay/rust-toolchain@nightly
 
     - name: build docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,12 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  doc-build:
+    - uses: dtolnay/rust-toolchain@nightly
+
+    - name: build docs
+      run: RUSTDOCFLAGS="--cfg docsrs" cargo doc
+
   build:
     runs-on: ubuntu-24.04
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,6 @@ v5 = []
 v4 = []
 uds = []
 ssh = ["dep:russh", "dep:russh-keys"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ podman machine start // Start the machine
 On linux you might initialize a client like this
 
 ```rust
-#[cfg(feature = "v5")]
 use podman_rest_client::PodmanRestClient;
 use podman_rest_client::Config;
 
@@ -70,7 +69,6 @@ let images = client.v5().images().image_list_libpod(None).await.unwrap();
 On macOs you might initialize a client like this with an ssh url and identity file
 
 ```rust
-#[cfg(feature = "v5")]
 let client = PodmanRestClient::new(Config {
     uri: "ssh://core@127.0.0.1:63169/run/user/501/podman/podman.sock".to_string(),
     identity_file: Some("/path/to/identity_file".into()),
@@ -83,7 +81,6 @@ You can also use `Config::guess()` which tries to find the default path to the p
 socket depending on the platform you are on.
 
 ```rust
-#[cfg(feature = "v5")]
 // Setup the default configuration
 let config = Config::guess().await.unwrap();
 
@@ -100,7 +97,6 @@ If you import the `podman_rest_client::v5::Client` trait you  can directly call 
 functions from a client:
 
 ```rust
-#[cfg(feature = "v5")]
 use podman_rest_client::v5::Client;
 client.images().image_list_libpod(None).await;
 ```
@@ -109,7 +105,6 @@ You can also use various api traits like `podman_rest_client::v5::apis::Images` 
 call the individual request functions:
 
 ```rust
-#[cfg(feature = "v5")]
 use podman_rest_client::v5::apis::Images;
 client.image_list_libpod(None).await;
 ```
@@ -117,7 +112,7 @@ client.image_list_libpod(None).await;
 
 ## Features
 
-The default feature set is ["v5", "uds", "ssh"].
+The default feature set is `["v5", "uds", "ssh"]`.
 
 - `ssh`: Support for connecting to a podman through an ssh server.
 - `uds`: Support for connecting to podman through a unix domain socket.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(doc_cfg)]
 //! Provides an interface for querying the Podman REST API. Most of the interface is generated from
 //! the official Podman swagger file. It can connect to the Podman API over ssh to a unix socket
 //! and directly to a unix socket. Connections over ssh are  commonly necessary on macOs where the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(doc_cfg)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! Provides an interface for querying the Podman REST API. Most of the interface is generated from
 //! the official Podman swagger file. It can connect to the Podman API over ssh to a unix socket
 //! and directly to a unix socket. Connections over ssh are  commonly necessary on macOs where the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! On linux you might initialize a client like this
 //!
 //! ```no_run
-//! #[cfg(feature = "v5")]
+//! # #[cfg(feature = "v5")]
 //! # tokio_test::block_on(async {
 //! use podman_rest_client::PodmanRestClient;
 //! use podman_rest_client::Config;
@@ -64,7 +64,7 @@
 //! On macOs you might initialize a client like this with an ssh url and identity file
 //!
 //! ```no_run
-//! #[cfg(feature = "v5")]
+//! # #[cfg(feature = "v5")]
 //! # tokio_test::block_on(async {
 //! # use podman_rest_client::PodmanRestClient;
 //! # use podman_rest_client::Config;
@@ -81,7 +81,7 @@
 //! socket depending on the platform you are on.
 //!
 //! ```no_run
-//! #[cfg(feature = "v5")]
+//! # #[cfg(feature = "v5")]
 //! # tokio_test::block_on(async {
 //! # use podman_rest_client::PodmanRestClient;
 //! # use podman_rest_client::Config;
@@ -102,7 +102,7 @@
 //! functions from a client:
 //!
 //! ```
-//! #[cfg(feature = "v5")]
+//! # #[cfg(feature = "v5")]
 //! # tokio_test::block_on(async {
 //! # use podman_rest_client::PodmanRestClient;
 //! # use podman_rest_client::Config;
@@ -118,7 +118,7 @@
 //! call the individual request functions:
 //!
 //! ```
-//! #[cfg(feature = "v5")]
+//! # #[cfg(feature = "v5")]
 //! # tokio_test::block_on(async {
 //! # use podman_rest_client::PodmanRestClient;
 //! # use podman_rest_client::Config;
@@ -133,7 +133,7 @@
 //!
 //! ## Features
 //!
-//! The default feature set is ["v5", "uds", "ssh"].
+//! The default feature set is `["v5", "uds", "ssh"]`.
 //!
 //! - `ssh`: Support for connecting to a podman through an ssh server.
 //! - `uds`: Support for connecting to podman through a unix domain socket.


### PR DESCRIPTION
The documentation build is failing on docs.rs as reported here: #18

* `#![feature(doc_cfg)]` needs to be added to `lib.rs`. 🤞 This should fix the docs.rs build.
* Added a CI job to test `RUSTDOCFLAGS="--cfg docsrs" cargo doc --all-features` using nightly rust. Which hopefully validates that the docs will build on rust nightly and on docs.rs in the future.
* Minor doc cleanups in the README.md

