### PR TITLE
Limit public interface

### DIFF
--- a/bin/generate-podman-api.sh
+++ b/bin/generate-podman-api.sh
@@ -1,7 +1,7 @@
 # Use openapi-client-gen to auto generate the basic podman-autogen-api client
-cargo run -p openapi-client-gen -- --module --common-dir ./src/api_common ./swagger/swagger-v5.1.0.modified.yaml ./src/v5
+cargo run -p openapi-client-gen -- --skip-default-client --module --common-dir ./src/api_common ./swagger/swagger-v5.1.0.modified.yaml ./src/v5
 
-cargo run -p openapi-client-gen -- --module --common-dir ./src/api_common ./swagger/swagger-v4.9.modified.yaml ./src/v4
+cargo run -p openapi-client-gen -- --skip-default-client --module --common-dir ./src/api_common ./swagger/swagger-v4.9.modified.yaml ./src/v4
 
 # Format the auto generated code
 cargo fmt

--- a/openapi-client-gen/src/generate/rust_hyper_legacy/mod.rs
+++ b/openapi-client-gen/src/generate/rust_hyper_legacy/mod.rs
@@ -17,6 +17,7 @@ pub struct GeneratorConfig<'a> {
     pub common_dir: Option<String>,
     pub api_module: Option<String>,
     pub common_module: Option<String>,
+    pub skip_default_client: bool,
 }
 
 pub fn generate<'a>(config: &'a mut GeneratorConfig<'a>) -> Result<(), Error> {
@@ -52,7 +53,7 @@ pub fn generate<'a>(config: &'a mut GeneratorConfig<'a>) -> Result<(), Error> {
         )?;
         files.create(
             src_dir.join("mod.rs"),
-            include_str!("./templates/api_specific_mod.rs"),
+            templates::api_specific_mod::render(config.skip_default_client)?,
         )?;
     } else {
         files.create(src_dir.join("mod.rs"), include_str!("./templates/lib.rs"))?;
@@ -105,7 +106,12 @@ pub fn generate<'a>(config: &'a mut GeneratorConfig<'a>) -> Result<(), Error> {
 
     files.create(
         src_dir.join("client.rs"),
-        templates::client::client(spec, &common_module, &api_module_str)?,
+        templates::client::client(
+            spec,
+            &common_module,
+            &api_module_str,
+            config.skip_default_client,
+        )?,
     )?;
 
     common_files.create(

--- a/openapi-client-gen/src/generate/rust_hyper_legacy/templates/api_specific_mod.rs
+++ b/openapi-client-gen/src/generate/rust_hyper_legacy/templates/api_specific_mod.rs
@@ -1,7 +1,24 @@
-pub mod apis;
-mod client;
-pub mod models;
-pub mod params;
+use quote::quote;
 
-pub use client::APIClient;
-pub use client::Client;
+use crate::error::Error;
+
+pub fn render(skip_default_client: bool) -> Result<String, Error> {
+    let maybe_api_client = if skip_default_client {
+        None
+    } else {
+        Some(quote! { pub use client::APIClient; })
+    };
+
+    let code = quote! {
+        pub mod apis;
+        mod client;
+        pub mod models;
+        pub mod params;
+
+        #maybe_api_client
+        pub use client::Client;
+    };
+
+    let syn_file: syn::File = syn::parse2(code).unwrap();
+    Ok(prettyplease::unparse(&syn_file))
+}

--- a/openapi-client-gen/src/generate/rust_hyper_legacy/templates/client.rs
+++ b/openapi-client-gen/src/generate/rust_hyper_legacy/templates/client.rs
@@ -1,4 +1,4 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
 use crate::lang::rust::{ident, struct_name, to_doc_comment, var_name};
@@ -8,23 +8,53 @@ pub fn client(
     spec: &Spec,
     common_module: &syn::Path,
     api_module_str: &str,
+    skip_default_client: bool,
 ) -> Result<String, Error> {
     let api_module: syn::Path = syn::parse_str(api_module_str)?;
     let api_implementations = api_implementations(spec, &api_module);
     let api_trait_functions = api_trait_functions(spec);
     let api_impl_functions = api_impl_functions(spec, &api_module);
+    let macro_name = ident(&format!("impl_{}_traits", &var_name(api_module_str)));
+    let default_client = if skip_default_client {
+        None
+    } else {
+        Some(default_client(&macro_name, common_module))
+    };
     let apis = spec.tags.values().map(|tag| {
         let struct_name = struct_name(&tag.name);
         quote! {
             apis::#struct_name
         }
     });
-    let macro_name = ident(&format!("impl_{}_traits", &var_name(api_module_str)));
-    log::warn!("{}", macro_name);
 
     let code = quote! {
         use super::apis;
         use #common_module::config::HasConfig;
+
+        #default_client
+
+        pub trait Client: HasConfig + Send + Sync + #(#apis+)* {
+            #(#api_trait_functions)*
+        }
+
+        #[macro_export]
+        macro_rules! #macro_name {
+            ($struct_name:ident) => {
+                impl #api_module::Client for $struct_name {
+                    #(#api_impl_functions)*
+                }
+                #(#api_implementations)*
+            };
+        }
+
+    };
+
+    let syn_file: syn::File = syn::parse2(code)?;
+    Ok(prettyplease::unparse(&syn_file))
+}
+
+fn default_client(macro_name: &Ident, common_module: &syn::Path) -> TokenStream {
+    quote! {
         use #common_module::config::ClientConfig;
         use #common_module::config::Connector;
         use #common_module::config::Config;
@@ -48,26 +78,8 @@ pub fn client(
             }
         }
 
-        pub trait Client: HasConfig + Send + Sync + #(#apis+)* {
-            #(#api_trait_functions)*
-        }
-
         #macro_name!(APIClient);
-
-        #[macro_export]
-        macro_rules! #macro_name {
-            ($struct_name:ident) => {
-                impl #api_module::Client for $struct_name {
-                    #(#api_impl_functions)*
-                }
-                #(#api_implementations)*
-            };
-        }
-
-    };
-
-    let syn_file: syn::File = syn::parse2(code)?;
-    Ok(prettyplease::unparse(&syn_file))
+    }
 }
 
 fn api_implementations<'a>(

--- a/openapi-client-gen/src/generate/rust_hyper_legacy/templates/mod.rs
+++ b/openapi-client-gen/src/generate/rust_hyper_legacy/templates/mod.rs
@@ -1,3 +1,4 @@
+pub mod api_specific_mod;
 pub mod apis;
 pub mod client;
 pub mod config;

--- a/openapi-client-gen/src/main.rs
+++ b/openapi-client-gen/src/main.rs
@@ -34,6 +34,9 @@ struct Cli {
     /// Module name for common files. If not specified, we guess based on the nearest src folder.
     #[arg(long)]
     common_module: Option<String>,
+    /// Do not generate the default client struct
+    #[arg(long)]
+    skip_default_client: bool,
 }
 
 fn main() -> Result<(), Error> {
@@ -55,13 +58,6 @@ fn app() -> Result<(), Error> {
     let contents = fs::read_to_string(cli.input_spec_file)?;
     let spec = spec::Spec::from_yaml_string(&contents)?;
 
-    //let mut file_tracker = FileTracker::new(cli.target_dir);
-    //let common_file_tracker: &mut FileTracker = if let Some(common_dir) = cli.common_dir {
-    //    &mut FileTracker::new(common_dir)
-    //} else {
-    //    &mut file_tracker
-    //};
-
     generate::rust_hyper_legacy::generate(&mut generate::rust_hyper_legacy::GeneratorConfig {
         spec: &spec,
         target_dir: &cli.target_dir,
@@ -69,6 +65,7 @@ fn app() -> Result<(), Error> {
         common_dir: cli.common_dir,
         api_module: cli.api_module,
         common_module: cli.common_module,
+        skip_default_client: cli.skip_default_client,
     })?;
 
     Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
+pub enum ClientError {
     #[cfg(feature = "ssh")]
     #[error("SSH error: {0}")]
     Ssh(#[from] russh::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,11 +150,13 @@ mod ssh;
 #[cfg(feature = "uds")]
 mod unix_socket;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "v4")))]
 #[cfg(feature = "v4")]
 pub mod v4;
 
 pub mod api_common;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "v5")))]
 #[cfg(feature = "v5")]
 pub mod v5;
 pub use config::Config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@ mod api_common;
 #[cfg_attr(docsrs, doc(cfg(feature = "v5")))]
 #[cfg(feature = "v5")]
 pub mod v5;
+pub use api_common::Error;
 pub use config::Config;
-pub use error::Error;
+pub use error::ClientError;
 pub use podman_rest_client::PodmanRestClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ mod unix_socket;
 #[cfg(feature = "v4")]
 pub mod v4;
 
-pub mod api_common;
+mod api_common;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "v5")))]
 #[cfg(feature = "v5")]

--- a/src/unix_socket.rs
+++ b/src/unix_socket.rs
@@ -12,7 +12,7 @@ use tokio::net::UnixStream;
 use tower_service::Service;
 
 use crate::api_common::Connector;
-use crate::error::Error;
+use crate::error::ClientError;
 
 #[derive(Clone)]
 pub(crate) struct UnixConnector {
@@ -33,7 +33,7 @@ impl Connector for UnixConnector {}
 
 impl Service<Uri> for UnixConnector {
     type Response = UnixStreamWrapper;
-    type Error = Error;
+    type Error = ClientError;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/src/v4/client.rs
+++ b/src/v4/client.rs
@@ -1,24 +1,5 @@
 use super::apis;
-use crate::api_common::config::ClientConfig;
-use crate::api_common::config::Config;
-use crate::api_common::config::Connector;
 use crate::api_common::config::HasConfig;
-use crate::impl_crate_v4_traits;
-pub struct APIClient {
-    config: Box<dyn ClientConfig>,
-}
-impl APIClient {
-    pub fn new<C: Connector>(config: Config<C>) -> APIClient {
-        APIClient {
-            config: Box::new(config),
-        }
-    }
-}
-impl HasConfig for APIClient {
-    fn get_config(&self) -> &dyn ClientConfig {
-        &*self.config
-    }
-}
 pub trait Client:
     HasConfig
     + Send
@@ -73,7 +54,6 @@ pub trait Client:
     /// Actions related to volumes for the compatibility endpoints
     fn volumes_compat(&self) -> &dyn apis::VolumesCompat;
 }
-impl_crate_v4_traits!(APIClient);
 #[macro_export]
 macro_rules! impl_crate_v4_traits {
     ($struct_name:ident) => {

--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -2,6 +2,4 @@ pub mod apis;
 mod client;
 pub mod models;
 pub mod params;
-
-pub use client::APIClient;
 pub use client::Client;

--- a/src/v5/client.rs
+++ b/src/v5/client.rs
@@ -1,24 +1,5 @@
 use super::apis;
-use crate::api_common::config::ClientConfig;
-use crate::api_common::config::Config;
-use crate::api_common::config::Connector;
 use crate::api_common::config::HasConfig;
-use crate::impl_crate_v5_traits;
-pub struct APIClient {
-    config: Box<dyn ClientConfig>,
-}
-impl APIClient {
-    pub fn new<C: Connector>(config: Config<C>) -> APIClient {
-        APIClient {
-            config: Box::new(config),
-        }
-    }
-}
-impl HasConfig for APIClient {
-    fn get_config(&self) -> &dyn ClientConfig {
-        &*self.config
-    }
-}
 pub trait Client:
     HasConfig
     + Send
@@ -73,7 +54,6 @@ pub trait Client:
     /// Actions related to volumes for the compatibility endpoints
     fn volumes_compat(&self) -> &dyn apis::VolumesCompat;
 }
-impl_crate_v5_traits!(APIClient);
 #[macro_export]
 macro_rules! impl_crate_v5_traits {
     ($struct_name:ident) => {

--- a/src/v5/mod.rs
+++ b/src/v5/mod.rs
@@ -2,6 +2,4 @@ pub mod apis;
 mod client;
 pub mod models;
 pub mod params;
-
-pub use client::APIClient;
 pub use client::Client;

--- a/tests/v5.rs
+++ b/tests/v5.rs
@@ -4,7 +4,7 @@ use assert_matches::assert_matches;
 use podman_rest_client::v5::models;
 use podman_rest_client::v5::params;
 use podman_rest_client::v5::Client;
-use podman_rest_client::Error;
+use podman_rest_client::ClientError;
 use podman_rest_client::{Config, PodmanRestClient};
 
 mod v5_common;
@@ -256,5 +256,5 @@ async fn it_errors_on_invalid_uris() {
     .err()
     .unwrap();
 
-    assert_matches!(err, Error::InvalidScheme);
+    assert_matches!(err, ClientError::InvalidScheme);
 }


### PR DESCRIPTION
The library is exporting more than necessary.

* We don't need `APIClient` or most of `api_common`
* Error is renamed to ClientError as it represents errors that only occur when initializing a Client.
* The Error exported at the top of the crate is the Error that api requests may return.
* Mark v5 and v4 modules in docs as only being available with the relevant feature flags