### PR TITLE
Image exports as tarball streaming bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ ssh = ["dep:russh", "dep:russh-keys"]
 [package.metadata.docs.rs]
 all-features = true
 
-[package.metadata.release]
-pre-release-commit-message="v{{version}}"
+[workspace.metadata.release]
+allow-branch = ["master"]
+pre-release-commit-message = "v{{version}}"
 consolidate-commits = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,13 @@ tokio = { version = "1.38.0", features = ["process"] }
 tower-service = "0.3.2"
 serde_path_to_error = "0.1.16"
 url = "2.5.2"
+bytes = "1.7.1"
+futures = "0.3.30"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-tokio = { version = "1.38.0", features = ["process", "macros"] }
+tar = "0.4.41"
+tokio = { version = "1.38.0", features = ["process", "macros", "fs"] }
 tokio-test = "0.4.4"
 
 [features]

--- a/openapi-client-gen/src/generate/rust_hyper_legacy/templates/request.rs
+++ b/openapi-client-gen/src/generate/rust_hyper_legacy/templates/request.rs
@@ -1,14 +1,39 @@
+use futures::stream;
+use futures::stream::StreamExt;
+use futures::Stream;
 use http_body_util::BodyExt;
 use serde_path_to_error::deserialize;
+use std::pin::Pin;
 
 use super::config::ClientConfig;
 use super::error::Error;
 
+pub async fn execute_request_unit(
+    config: &dyn ClientConfig,
+    request: Result<http::request::Request<String>, Error>,
+) -> Result<(), Error> {
+    execute_request_bytes(config, request).await?;
+    Ok(())
+}
+
+pub async fn execute_request_json<U>(
+    config: &dyn ClientConfig,
+    request: Result<http::request::Request<String>, Error>,
+) -> Result<U, Error>
+where
+    for<'a> U: serde::Deserialize<'a>,
+{
+    let bytes = execute_request_bytes(config, request).await?;
+    let deserializer = &mut serde_json::Deserializer::from_slice(&bytes);
+
+    Ok(deserialize(deserializer)?)
+}
+
 pub async fn execute_request_bytes(
     config: &dyn ClientConfig,
-    request: http::request::Request<String>,
+    request: Result<http::request::Request<String>, Error>,
 ) -> Result<hyper::body::Bytes, Error> {
-    let response = config.request(request).await?;
+    let response = config.request(request?).await?;
     let status = response.status();
     let bytes = response.into_body().collect().await?.to_bytes();
     if status.is_success() {
@@ -21,23 +46,33 @@ pub async fn execute_request_bytes(
     }
 }
 
-pub async fn execute_request_unit(
-    config: &dyn ClientConfig,
-    request: http::request::Request<String>,
-) -> Result<(), Error> {
-    execute_request_bytes(config, request).await?;
-    Ok(())
-}
+pub fn execute_request_stream<'a>(
+    config: &'a dyn ClientConfig,
+    request: Result<http::request::Request<String>, Error>,
+) -> Pin<Box<dyn Stream<Item = Result<bytes::Bytes, Error>> + 'a>> {
+    let result = async move {
+        let response = config.request(request?).await?;
+        let status = response.status();
+        let body = response.into_body();
 
-pub async fn execute_request_json<U>(
-    config: &dyn ClientConfig,
-    request: http::request::Request<String>,
-) -> Result<U, Error>
-where
-    for<'a> U: serde::Deserialize<'a>,
-{
-    let bytes = execute_request_bytes(config, request).await?;
-    let deserializer = &mut serde_json::Deserializer::from_slice(&bytes);
-
-    Ok(deserialize(deserializer)?)
+        if status.is_success() {
+            Ok(Box::pin(body.into_data_stream().map(
+                |result| match result {
+                    Ok(bytes) => Ok(bytes),
+                    Err(err) => Err(err.into()),
+                },
+            )))
+        } else {
+            let bytes = body.collect().await?.to_bytes();
+            Err(Error::Api {
+                code: status,
+                body: bytes.into(),
+            })
+        }
+    };
+    Box::pin(stream::once(result).flat_map(|result| match result {
+        Ok(stream) => stream,
+        Err(err) => Box::pin(stream::once(async { Err(err) }))
+            as Pin<Box<dyn Stream<Item = Result<_, Error>>>>,
+    }))
 }

--- a/openapi-client-gen/src/lang/rust.rs
+++ b/openapi-client-gen/src/lang/rust.rs
@@ -200,6 +200,9 @@ pub fn model_type(model: &Model, models: &BTreeMap<String, Model>) -> Result<Tok
                 Err(Error::MissingModelRef(ref_str.into()))?
             }
         }
+        ModelData::Tarball => {
+            quote! { bytes::Bytes }
+        }
     })
 }
 

--- a/openapi-client-gen/src/model.rs
+++ b/openapi-client-gen/src/model.rs
@@ -24,12 +24,16 @@ pub enum ModelData {
     HashMap(Box<Model>, bool),
     ArbitraryValue,
     NoValue,
+    Tarball,
     Ref(String),
 }
 
 impl ModelData {
     pub fn is_no_value(&self) -> bool {
         matches!(&self, ModelData::NoValue)
+    }
+    pub fn is_stream(&self) -> bool {
+        matches!(&self, ModelData::Tarball)
     }
 }
 

--- a/src/api_common/request.rs
+++ b/src/api_common/request.rs
@@ -1,14 +1,39 @@
+use futures::stream;
+use futures::stream::StreamExt;
+use futures::Stream;
 use http_body_util::BodyExt;
 use serde_path_to_error::deserialize;
+use std::pin::Pin;
 
 use super::config::ClientConfig;
 use super::error::Error;
 
+pub async fn execute_request_unit(
+    config: &dyn ClientConfig,
+    request: Result<http::request::Request<String>, Error>,
+) -> Result<(), Error> {
+    execute_request_bytes(config, request).await?;
+    Ok(())
+}
+
+pub async fn execute_request_json<U>(
+    config: &dyn ClientConfig,
+    request: Result<http::request::Request<String>, Error>,
+) -> Result<U, Error>
+where
+    for<'a> U: serde::Deserialize<'a>,
+{
+    let bytes = execute_request_bytes(config, request).await?;
+    let deserializer = &mut serde_json::Deserializer::from_slice(&bytes);
+
+    Ok(deserialize(deserializer)?)
+}
+
 pub async fn execute_request_bytes(
     config: &dyn ClientConfig,
-    request: http::request::Request<String>,
+    request: Result<http::request::Request<String>, Error>,
 ) -> Result<hyper::body::Bytes, Error> {
-    let response = config.request(request).await?;
+    let response = config.request(request?).await?;
     let status = response.status();
     let bytes = response.into_body().collect().await?.to_bytes();
     if status.is_success() {
@@ -21,23 +46,33 @@ pub async fn execute_request_bytes(
     }
 }
 
-pub async fn execute_request_unit(
-    config: &dyn ClientConfig,
-    request: http::request::Request<String>,
-) -> Result<(), Error> {
-    execute_request_bytes(config, request).await?;
-    Ok(())
-}
+pub fn execute_request_stream<'a>(
+    config: &'a dyn ClientConfig,
+    request: Result<http::request::Request<String>, Error>,
+) -> Pin<Box<dyn Stream<Item = Result<bytes::Bytes, Error>> + 'a>> {
+    let result = async move {
+        let response = config.request(request?).await?;
+        let status = response.status();
+        let body = response.into_body();
 
-pub async fn execute_request_json<U>(
-    config: &dyn ClientConfig,
-    request: http::request::Request<String>,
-) -> Result<U, Error>
-where
-    for<'a> U: serde::Deserialize<'a>,
-{
-    let bytes = execute_request_bytes(config, request).await?;
-    let deserializer = &mut serde_json::Deserializer::from_slice(&bytes);
-
-    Ok(deserialize(deserializer)?)
+        if status.is_success() {
+            Ok(Box::pin(body.into_data_stream().map(
+                |result| match result {
+                    Ok(bytes) => Ok(bytes),
+                    Err(err) => Err(err.into()),
+                },
+            )))
+        } else {
+            let bytes = body.collect().await?.to_bytes();
+            Err(Error::Api {
+                code: status,
+                body: bytes.into(),
+            })
+        }
+    };
+    Box::pin(stream::once(result).flat_map(|result| match result {
+        Ok(stream) => stream,
+        Err(err) => Box::pin(stream::once(async { Err(err) }))
+            as Pin<Box<dyn Stream<Item = Result<_, Error>>>>,
+    }))
 }

--- a/src/v4/apis/containers.rs
+++ b/src/v4/apis/containers.rs
@@ -11,58 +11,55 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageCommitLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/commit");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("container", params.container);
-                if let Some(author) = params.author {
-                    query_pairs.append_pair("author", author);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(changes) = params.changes {
-                    query_pairs.append_pair(
-                        "changes",
-                        &changes
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+                request_path.push_str("/libpod/commit");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("container", params.container);
+                    if let Some(author) = params.author {
+                        query_pairs.append_pair("author", author);
+                    }
+                    if let Some(changes) = params.changes {
+                        for value in changes {
+                            query_pairs.append_pair("changes", &value.to_string());
+                        }
+                    }
+                    if let Some(comment) = params.comment {
+                        query_pairs.append_pair("comment", comment);
+                    }
+                    if let Some(format) = params.format {
+                        query_pairs.append_pair("format", format);
+                    }
+                    if let Some(pause) = params.pause {
+                        query_pairs.append_pair("pause", &pause.to_string());
+                    }
+                    if let Some(squash) = params.squash {
+                        query_pairs.append_pair("squash", &squash.to_string());
+                    }
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
                 }
-                if let Some(comment) = params.comment {
-                    query_pairs.append_pair("comment", comment);
-                }
-                if let Some(format) = params.format {
-                    query_pairs.append_pair("format", format);
-                }
-                if let Some(pause) = params.pause {
-                    query_pairs.append_pair("pause", &pause.to_string());
-                }
-                if let Some(squash) = params.squash {
-                    query_pairs.append_pair("squash", &squash.to_string());
-                }
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
-                }
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
-                }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /libpod/containers/{name}
     /// Delete container
@@ -72,39 +69,41 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerDeleteLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(depend) = params.depend {
-                    query_pairs.append_pair("depend", &depend.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+                request_path.push_str("/libpod/containers/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(depend) = params.depend {
+                        query_pairs.append_pair("depend", &depend.to_string());
+                    }
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                    if let Some(ignore) = params.ignore {
+                        query_pairs.append_pair("ignore", &ignore.to_string());
+                    }
+                    if let Some(timeout) = params.timeout {
+                        query_pairs.append_pair("timeout", &timeout.to_string());
+                    }
+                    if let Some(v) = params.v {
+                        query_pairs.append_pair("v", &v.to_string());
+                    }
                 }
-                if let Some(ignore) = params.ignore {
-                    query_pairs.append_pair("ignore", &ignore.to_string());
-                }
-                if let Some(timeout) = params.timeout {
-                    query_pairs.append_pair("timeout", &timeout.to_string());
-                }
-                if let Some(v) = params.v {
-                    query_pairs.append_pair("v", &v.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/archive
     /// Copy files into a container
@@ -115,31 +114,33 @@ pub trait Containers: HasConfig + Send + Sync {
         params: Option<super::super::params::PutContainerArchiveLibpod<'a>>,
         request: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/archive");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("path", params.path);
-                if let Some(pause) = params.pause {
-                    query_pairs.append_pair("pause", &pause.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/archive");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("path", params.path);
+                    if let Some(pause) = params.pause {
+                        query_pairs.append_pair("pause", &pause.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/attach
     /// Attach to a container
@@ -235,42 +236,44 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerAttachLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/attach");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(detach_keys) = params.detach_keys {
-                    query_pairs.append_pair("detachKeys", detach_keys);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(logs) = params.logs {
-                    query_pairs.append_pair("logs", &logs.to_string());
+                request_path.push_str("/libpod/containers/{name}/attach");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(detach_keys) = params.detach_keys {
+                        query_pairs.append_pair("detachKeys", detach_keys);
+                    }
+                    if let Some(logs) = params.logs {
+                        query_pairs.append_pair("logs", &logs.to_string());
+                    }
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(stdout) = params.stdout {
+                        query_pairs.append_pair("stdout", &stdout.to_string());
+                    }
+                    if let Some(stderr) = params.stderr {
+                        query_pairs.append_pair("stderr", &stderr.to_string());
+                    }
+                    if let Some(stdin) = params.stdin {
+                        query_pairs.append_pair("stdin", &stdin.to_string());
+                    }
                 }
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
-                }
-                if let Some(stdout) = params.stdout {
-                    query_pairs.append_pair("stdout", &stdout.to_string());
-                }
-                if let Some(stderr) = params.stderr {
-                    query_pairs.append_pair("stderr", &stderr.to_string());
-                }
-                if let Some(stdin) = params.stdin {
-                    query_pairs.append_pair("stdin", &stdin.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/changes
     /// Report on changes to container's filesystem; adds, deletes or modifications.
@@ -284,30 +287,32 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerChangesLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/changes");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(parent) = params.parent {
-                    query_pairs.append_pair("parent", parent);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(diff_type) = params.diff_type {
-                    query_pairs.append_pair("diffType", diff_type);
+                request_path.push_str("/libpod/containers/{name}/changes");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(parent) = params.parent {
+                        query_pairs.append_pair("parent", parent);
+                    }
+                    if let Some(diff_type) = params.diff_type {
+                        query_pairs.append_pair("diffType", diff_type);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/checkpoint
     /// Checkpoint a container
@@ -316,54 +321,56 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerCheckpointLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/checkpoint");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(keep) = params.keep {
-                    query_pairs.append_pair("keep", &keep.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(leave_running) = params.leave_running {
-                    query_pairs.append_pair("leaveRunning", &leave_running.to_string());
+                request_path.push_str("/libpod/containers/{name}/checkpoint");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(keep) = params.keep {
+                        query_pairs.append_pair("keep", &keep.to_string());
+                    }
+                    if let Some(leave_running) = params.leave_running {
+                        query_pairs.append_pair("leaveRunning", &leave_running.to_string());
+                    }
+                    if let Some(tcp_established) = params.tcp_established {
+                        query_pairs.append_pair("tcpEstablished", &tcp_established.to_string());
+                    }
+                    if let Some(export) = params.export {
+                        query_pairs.append_pair("export", &export.to_string());
+                    }
+                    if let Some(ignore_root_fs) = params.ignore_root_fs {
+                        query_pairs.append_pair("ignoreRootFS", &ignore_root_fs.to_string());
+                    }
+                    if let Some(ignore_volumes) = params.ignore_volumes {
+                        query_pairs.append_pair("ignoreVolumes", &ignore_volumes.to_string());
+                    }
+                    if let Some(pre_checkpoint) = params.pre_checkpoint {
+                        query_pairs.append_pair("preCheckpoint", &pre_checkpoint.to_string());
+                    }
+                    if let Some(with_previous) = params.with_previous {
+                        query_pairs.append_pair("withPrevious", &with_previous.to_string());
+                    }
+                    if let Some(file_locks) = params.file_locks {
+                        query_pairs.append_pair("fileLocks", &file_locks.to_string());
+                    }
+                    if let Some(print_stats) = params.print_stats {
+                        query_pairs.append_pair("printStats", &print_stats.to_string());
+                    }
                 }
-                if let Some(tcp_established) = params.tcp_established {
-                    query_pairs.append_pair("tcpEstablished", &tcp_established.to_string());
-                }
-                if let Some(export) = params.export {
-                    query_pairs.append_pair("export", &export.to_string());
-                }
-                if let Some(ignore_root_fs) = params.ignore_root_fs {
-                    query_pairs.append_pair("ignoreRootFS", &ignore_root_fs.to_string());
-                }
-                if let Some(ignore_volumes) = params.ignore_volumes {
-                    query_pairs.append_pair("ignoreVolumes", &ignore_volumes.to_string());
-                }
-                if let Some(pre_checkpoint) = params.pre_checkpoint {
-                    query_pairs.append_pair("preCheckpoint", &pre_checkpoint.to_string());
-                }
-                if let Some(with_previous) = params.with_previous {
-                    query_pairs.append_pair("withPrevious", &with_previous.to_string());
-                }
-                if let Some(file_locks) = params.file_locks {
-                    query_pairs.append_pair("fileLocks", &file_locks.to_string());
-                }
-                if let Some(print_stats) = params.print_stats {
-                    query_pairs.append_pair("printStats", &print_stats.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/exists
     /// Check if container exists
@@ -372,21 +379,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/export
     /// Export a container
@@ -395,21 +404,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/export");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/export");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/healthcheck
     /// Run a container's healthcheck
@@ -418,21 +429,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/healthcheck");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/healthcheck");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/init
     /// Initialize a container
@@ -441,21 +454,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/init");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/init");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/json
     /// Inspect container
@@ -465,27 +480,29 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerInspectLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(size) = params.size {
-                    query_pairs.append_pair("size", &size.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(size) = params.size {
+                        query_pairs.append_pair("size", &size.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/kill
     /// Kill container
@@ -495,27 +512,29 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerKillLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/kill");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(signal) = params.signal {
-                    query_pairs.append_pair("signal", signal);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/kill");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(signal) = params.signal {
+                        query_pairs.append_pair("signal", signal);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/logs
     /// Get container logs
@@ -527,45 +546,47 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerLogsLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/logs");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(follow) = params.follow {
-                    query_pairs.append_pair("follow", &follow.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(stdout) = params.stdout {
-                    query_pairs.append_pair("stdout", &stdout.to_string());
+                request_path.push_str("/libpod/containers/{name}/logs");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(follow) = params.follow {
+                        query_pairs.append_pair("follow", &follow.to_string());
+                    }
+                    if let Some(stdout) = params.stdout {
+                        query_pairs.append_pair("stdout", &stdout.to_string());
+                    }
+                    if let Some(stderr) = params.stderr {
+                        query_pairs.append_pair("stderr", &stderr.to_string());
+                    }
+                    if let Some(since) = params.since {
+                        query_pairs.append_pair("since", since);
+                    }
+                    if let Some(until) = params.until {
+                        query_pairs.append_pair("until", until);
+                    }
+                    if let Some(timestamps) = params.timestamps {
+                        query_pairs.append_pair("timestamps", &timestamps.to_string());
+                    }
+                    if let Some(tail) = params.tail {
+                        query_pairs.append_pair("tail", tail);
+                    }
                 }
-                if let Some(stderr) = params.stderr {
-                    query_pairs.append_pair("stderr", &stderr.to_string());
-                }
-                if let Some(since) = params.since {
-                    query_pairs.append_pair("since", since);
-                }
-                if let Some(until) = params.until {
-                    query_pairs.append_pair("until", until);
-                }
-                if let Some(timestamps) = params.timestamps {
-                    query_pairs.append_pair("timestamps", &timestamps.to_string());
-                }
-                if let Some(tail) = params.tail {
-                    query_pairs.append_pair("tail", tail);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/mount
     /// Mount a container
@@ -574,21 +595,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/mount");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/mount");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/pause
     /// Pause a container
@@ -597,21 +620,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/pause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/pause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/rename
     /// Rename an existing container
@@ -621,25 +646,27 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerRenameLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/rename");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("name", params.name);
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/rename");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("name", params.name);
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/resize
     /// Resize a container's TTY
@@ -649,30 +676,32 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerResizeLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/resize");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(h) = params.h {
-                    query_pairs.append_pair("h", &h.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(w) = params.w {
-                    query_pairs.append_pair("w", &w.to_string());
+                request_path.push_str("/libpod/containers/{name}/resize");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(h) = params.h {
+                        query_pairs.append_pair("h", &h.to_string());
+                    }
+                    if let Some(w) = params.w {
+                        query_pairs.append_pair("w", &w.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/restart
     /// Restart a container
@@ -681,27 +710,29 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerRestartLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/restart");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", &t.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/restart");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", &t.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/restore
     /// Restore a container
@@ -711,57 +742,59 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerRestoreLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/restore");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(name) = params.name {
-                    query_pairs.append_pair("name", name);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(keep) = params.keep {
-                    query_pairs.append_pair("keep", &keep.to_string());
+                request_path.push_str("/libpod/containers/{name}/restore");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(name) = params.name {
+                        query_pairs.append_pair("name", name);
+                    }
+                    if let Some(keep) = params.keep {
+                        query_pairs.append_pair("keep", &keep.to_string());
+                    }
+                    if let Some(tcp_established) = params.tcp_established {
+                        query_pairs.append_pair("tcpEstablished", &tcp_established.to_string());
+                    }
+                    if let Some(import) = params.import {
+                        query_pairs.append_pair("import", &import.to_string());
+                    }
+                    if let Some(ignore_root_fs) = params.ignore_root_fs {
+                        query_pairs.append_pair("ignoreRootFS", &ignore_root_fs.to_string());
+                    }
+                    if let Some(ignore_volumes) = params.ignore_volumes {
+                        query_pairs.append_pair("ignoreVolumes", &ignore_volumes.to_string());
+                    }
+                    if let Some(ignore_static_ip) = params.ignore_static_ip {
+                        query_pairs.append_pair("ignoreStaticIP", &ignore_static_ip.to_string());
+                    }
+                    if let Some(ignore_static_mac) = params.ignore_static_mac {
+                        query_pairs.append_pair("ignoreStaticMAC", &ignore_static_mac.to_string());
+                    }
+                    if let Some(file_locks) = params.file_locks {
+                        query_pairs.append_pair("fileLocks", &file_locks.to_string());
+                    }
+                    if let Some(print_stats) = params.print_stats {
+                        query_pairs.append_pair("printStats", &print_stats.to_string());
+                    }
+                    if let Some(pod) = params.pod {
+                        query_pairs.append_pair("pod", pod);
+                    }
                 }
-                if let Some(tcp_established) = params.tcp_established {
-                    query_pairs.append_pair("tcpEstablished", &tcp_established.to_string());
-                }
-                if let Some(import) = params.import {
-                    query_pairs.append_pair("import", &import.to_string());
-                }
-                if let Some(ignore_root_fs) = params.ignore_root_fs {
-                    query_pairs.append_pair("ignoreRootFS", &ignore_root_fs.to_string());
-                }
-                if let Some(ignore_volumes) = params.ignore_volumes {
-                    query_pairs.append_pair("ignoreVolumes", &ignore_volumes.to_string());
-                }
-                if let Some(ignore_static_ip) = params.ignore_static_ip {
-                    query_pairs.append_pair("ignoreStaticIP", &ignore_static_ip.to_string());
-                }
-                if let Some(ignore_static_mac) = params.ignore_static_mac {
-                    query_pairs.append_pair("ignoreStaticMAC", &ignore_static_mac.to_string());
-                }
-                if let Some(file_locks) = params.file_locks {
-                    query_pairs.append_pair("fileLocks", &file_locks.to_string());
-                }
-                if let Some(print_stats) = params.print_stats {
-                    query_pairs.append_pair("printStats", &print_stats.to_string());
-                }
-                if let Some(pod) = params.pod {
-                    query_pairs.append_pair("pod", pod);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/start
     /// Start a container
@@ -770,27 +803,29 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStartLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/start");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(detach_keys) = params.detach_keys {
-                    query_pairs.append_pair("detachKeys", detach_keys);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/start");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(detach_keys) = params.detach_keys {
+                        query_pairs.append_pair("detachKeys", detach_keys);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/stats
     /// Get stats for a container
@@ -800,27 +835,29 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStatsLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/stats");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/stats");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/stop
     /// Stop a container
@@ -829,30 +866,32 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStopLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/stop");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(timeout) = params.timeout {
-                    query_pairs.append_pair("timeout", &timeout.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(ignore) = params.ignore {
-                    query_pairs.append_pair("Ignore", &ignore.to_string());
+                request_path.push_str("/libpod/containers/{name}/stop");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(timeout) = params.timeout {
+                        query_pairs.append_pair("timeout", &timeout.to_string());
+                    }
+                    if let Some(ignore) = params.ignore {
+                        query_pairs.append_pair("Ignore", &ignore.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/top
     /// List processes
@@ -862,40 +901,37 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerTopLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/top");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(delay) = params.delay {
-                    query_pairs.append_pair("delay", &delay.to_string());
+                request_path.push_str("/libpod/containers/{name}/top");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(delay) = params.delay {
+                        query_pairs.append_pair("delay", &delay.to_string());
+                    }
+                    if let Some(ps_args) = params.ps_args {
+                        for value in ps_args {
+                            query_pairs.append_pair("ps_args", &value.to_string());
+                        }
+                    }
                 }
-                if let Some(ps_args) = params.ps_args {
-                    query_pairs.append_pair(
-                        "ps_args",
-                        &ps_args
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/unmount
     /// Unmount a container
@@ -904,21 +940,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/unmount");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/unmount");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/unpause
     /// Unpause Container
@@ -926,21 +964,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/unpause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/unpause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/update
     /// Update an existing containers cgroup configuration
@@ -950,24 +990,26 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         resources: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/update");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&resources)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/update");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&resources)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/wait
     /// Wait on a container
@@ -977,37 +1019,34 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerWaitLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<i32, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/wait");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(condition) = params.condition {
-                    query_pairs.append_pair(
-                        "condition",
-                        &condition
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(interval) = params.interval {
-                    query_pairs.append_pair("interval", interval);
+                request_path.push_str("/libpod/containers/{name}/wait");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(condition) = params.condition {
+                        for value in condition {
+                            query_pairs.append_pair("condition", &value.to_string());
+                        }
+                    }
+                    if let Some(interval) = params.interval {
+                        query_pairs.append_pair("interval", interval);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/create
     /// Create a container
@@ -1015,23 +1054,25 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         create: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/json
     /// List containers
@@ -1040,44 +1081,46 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ContainerListLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(limit) = params.limit {
-                    query_pairs.append_pair("limit", &limit.to_string());
+                request_path.push_str("/libpod/containers/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(limit) = params.limit {
+                        query_pairs.append_pair("limit", &limit.to_string());
+                    }
+                    if let Some(namespace) = params.namespace {
+                        query_pairs.append_pair("namespace", &namespace.to_string());
+                    }
+                    if let Some(pod) = params.pod {
+                        query_pairs.append_pair("pod", &pod.to_string());
+                    }
+                    if let Some(size) = params.size {
+                        query_pairs.append_pair("size", &size.to_string());
+                    }
+                    if let Some(sync) = params.sync {
+                        query_pairs.append_pair("sync", &sync.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
                 }
-                if let Some(namespace) = params.namespace {
-                    query_pairs.append_pair("namespace", &namespace.to_string());
-                }
-                if let Some(pod) = params.pod {
-                    query_pairs.append_pair("pod", &pod.to_string());
-                }
-                if let Some(size) = params.size {
-                    query_pairs.append_pair("size", &size.to_string());
-                }
-                if let Some(sync) = params.sync {
-                    query_pairs.append_pair("sync", &sync.to_string());
-                }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/prune
     /// Delete stopped containers
@@ -1086,26 +1129,28 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ContainerPruneLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/showmounted
     /// Show mounted containers
@@ -1119,20 +1164,22 @@ pub trait Containers: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/showmounted");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/showmounted");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/stats
     /// Get stats for one or more containers
@@ -1141,39 +1188,36 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ContainersStatsAllLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/stats");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(containers) = params.containers {
-                    query_pairs.append_pair(
-                        "containers",
-                        &containers
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
+                request_path.push_str("/libpod/containers/stats");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(containers) = params.containers {
+                        for value in containers {
+                            query_pairs.append_pair("containers", &value.to_string());
+                        }
+                    }
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(interval) = params.interval {
+                        query_pairs.append_pair("interval", &interval.to_string());
+                    }
                 }
-                if let Some(interval) = params.interval {
-                    query_pairs.append_pair("interval", &interval.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/generate/{name}/systemd
     /// Generate Systemd Units
@@ -1189,94 +1233,76 @@ pub trait Containers: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/generate/{name}/systemd");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(use_name) = params.use_name {
-                    query_pairs.append_pair("useName", &use_name.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(new) = params.new {
-                    query_pairs.append_pair("new", &new.to_string());
+                request_path.push_str("/libpod/generate/{name}/systemd");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(use_name) = params.use_name {
+                        query_pairs.append_pair("useName", &use_name.to_string());
+                    }
+                    if let Some(new) = params.new {
+                        query_pairs.append_pair("new", &new.to_string());
+                    }
+                    if let Some(no_header) = params.no_header {
+                        query_pairs.append_pair("noHeader", &no_header.to_string());
+                    }
+                    if let Some(start_timeout) = params.start_timeout {
+                        query_pairs.append_pair("startTimeout", &start_timeout.to_string());
+                    }
+                    if let Some(stop_timeout) = params.stop_timeout {
+                        query_pairs.append_pair("stopTimeout", &stop_timeout.to_string());
+                    }
+                    if let Some(restart_policy) = params.restart_policy {
+                        query_pairs.append_pair("restartPolicy", restart_policy);
+                    }
+                    if let Some(container_prefix) = params.container_prefix {
+                        query_pairs.append_pair("containerPrefix", container_prefix);
+                    }
+                    if let Some(pod_prefix) = params.pod_prefix {
+                        query_pairs.append_pair("podPrefix", pod_prefix);
+                    }
+                    if let Some(separator) = params.separator {
+                        query_pairs.append_pair("separator", separator);
+                    }
+                    if let Some(restart_sec) = params.restart_sec {
+                        query_pairs.append_pair("restartSec", &restart_sec.to_string());
+                    }
+                    if let Some(wants) = params.wants {
+                        for value in wants {
+                            query_pairs.append_pair("wants", &value.to_string());
+                        }
+                    }
+                    if let Some(after) = params.after {
+                        for value in after {
+                            query_pairs.append_pair("after", &value.to_string());
+                        }
+                    }
+                    if let Some(requires) = params.requires {
+                        for value in requires {
+                            query_pairs.append_pair("requires", &value.to_string());
+                        }
+                    }
+                    if let Some(additional_env_variables) = params.additional_env_variables {
+                        for value in additional_env_variables {
+                            query_pairs.append_pair("additionalEnvVariables", &value.to_string());
+                        }
+                    }
                 }
-                if let Some(no_header) = params.no_header {
-                    query_pairs.append_pair("noHeader", &no_header.to_string());
-                }
-                if let Some(start_timeout) = params.start_timeout {
-                    query_pairs.append_pair("startTimeout", &start_timeout.to_string());
-                }
-                if let Some(stop_timeout) = params.stop_timeout {
-                    query_pairs.append_pair("stopTimeout", &stop_timeout.to_string());
-                }
-                if let Some(restart_policy) = params.restart_policy {
-                    query_pairs.append_pair("restartPolicy", restart_policy);
-                }
-                if let Some(container_prefix) = params.container_prefix {
-                    query_pairs.append_pair("containerPrefix", container_prefix);
-                }
-                if let Some(pod_prefix) = params.pod_prefix {
-                    query_pairs.append_pair("podPrefix", pod_prefix);
-                }
-                if let Some(separator) = params.separator {
-                    query_pairs.append_pair("separator", separator);
-                }
-                if let Some(restart_sec) = params.restart_sec {
-                    query_pairs.append_pair("restartSec", &restart_sec.to_string());
-                }
-                if let Some(wants) = params.wants {
-                    query_pairs.append_pair(
-                        "wants",
-                        &wants
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(after) = params.after {
-                    query_pairs.append_pair(
-                        "after",
-                        &after
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(requires) = params.requires {
-                    query_pairs.append_pair(
-                        "requires",
-                        &requires
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(additional_env_variables) = params.additional_env_variables {
-                    query_pairs.append_pair(
-                        "additionalEnvVariables",
-                        &additional_env_variables
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/generate/kube
     /// Generate a Kubernetes YAML file.
@@ -1285,47 +1311,43 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::GenerateKubeLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/generate/kube");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair(
-                    "names",
-                    &params
-                        .names
-                        .iter()
-                        .map(|e| e.to_string())
-                        .collect::<Vec<_>>()
-                        .join(","),
-                );
-                if let Some(service) = params.service {
-                    query_pairs.append_pair("service", &service.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(r#type) = params.r#type {
-                    query_pairs.append_pair("type", r#type);
+                request_path.push_str("/libpod/generate/kube");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    for value in params.names {
+                        query_pairs.append_pair("names", &value.to_string());
+                    }
+                    if let Some(service) = params.service {
+                        query_pairs.append_pair("service", &service.to_string());
+                    }
+                    if let Some(r#type) = params.r#type {
+                        query_pairs.append_pair("type", r#type);
+                    }
+                    if let Some(replicas) = params.replicas {
+                        query_pairs.append_pair("replicas", &replicas.to_string());
+                    }
+                    if let Some(no_trunc) = params.no_trunc {
+                        query_pairs.append_pair("noTrunc", &no_trunc.to_string());
+                    }
+                    if let Some(podman_only) = params.podman_only {
+                        query_pairs.append_pair("podmanOnly", &podman_only.to_string());
+                    }
                 }
-                if let Some(replicas) = params.replicas {
-                    query_pairs.append_pair("replicas", &replicas.to_string());
-                }
-                if let Some(no_trunc) = params.no_trunc {
-                    query_pairs.append_pair("noTrunc", &no_trunc.to_string());
-                }
-                if let Some(podman_only) = params.podman_only {
-                    query_pairs.append_pair("podmanOnly", &podman_only.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/kube/apply
     /// Apply a podman workload or Kubernetes YAML file.
@@ -1335,41 +1357,43 @@ pub trait Containers: HasConfig + Send + Sync {
         params: Option<super::super::params::KubeApplyLibpod<'a>>,
         request: String,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/kube/apply");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(ca_cert_file) = params.ca_cert_file {
-                    query_pairs.append_pair("caCertFile", ca_cert_file);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(kube_config) = params.kube_config {
-                    query_pairs.append_pair("kubeConfig", kube_config);
+                request_path.push_str("/libpod/kube/apply");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(ca_cert_file) = params.ca_cert_file {
+                        query_pairs.append_pair("caCertFile", ca_cert_file);
+                    }
+                    if let Some(kube_config) = params.kube_config {
+                        query_pairs.append_pair("kubeConfig", kube_config);
+                    }
+                    if let Some(namespace) = params.namespace {
+                        query_pairs.append_pair("namespace", namespace);
+                    }
+                    if let Some(service) = params.service {
+                        query_pairs.append_pair("service", &service.to_string());
+                    }
+                    if let Some(file) = params.file {
+                        query_pairs.append_pair("file", file);
+                    }
                 }
-                if let Some(namespace) = params.namespace {
-                    query_pairs.append_pair("namespace", namespace);
-                }
-                if let Some(service) = params.service {
-                    query_pairs.append_pair("service", &service.to_string());
-                }
-                if let Some(file) = params.file {
-                    query_pairs.append_pair("file", file);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// DELETE /libpod/play/kube
     /// Remove resources created from kube play
@@ -1378,26 +1402,28 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::PlayKubeDownLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/play/kube");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/play/kube");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/play/kube
     /// Play a Kubernetes YAML file.
@@ -1407,102 +1433,79 @@ pub trait Containers: HasConfig + Send + Sync {
         params: Option<super::super::params::PlayKubeLibpod<'a>>,
         request: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/play/kube");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(log_driver) = params.log_driver {
-                    query_pairs.append_pair("logDriver", log_driver);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(log_options) = params.log_options {
-                    query_pairs.append_pair(
-                        "logOptions",
-                        &log_options
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+                request_path.push_str("/libpod/play/kube");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(log_driver) = params.log_driver {
+                        query_pairs.append_pair("logDriver", log_driver);
+                    }
+                    if let Some(log_options) = params.log_options {
+                        for value in log_options {
+                            query_pairs.append_pair("logOptions", &value.to_string());
+                        }
+                    }
+                    if let Some(network) = params.network {
+                        for value in network {
+                            query_pairs.append_pair("network", &value.to_string());
+                        }
+                    }
+                    if let Some(no_hosts) = params.no_hosts {
+                        query_pairs.append_pair("noHosts", &no_hosts.to_string());
+                    }
+                    if let Some(no_trunc) = params.no_trunc {
+                        query_pairs.append_pair("noTrunc", &no_trunc.to_string());
+                    }
+                    if let Some(publish_ports) = params.publish_ports {
+                        for value in publish_ports {
+                            query_pairs.append_pair("publishPorts", &value.to_string());
+                        }
+                    }
+                    if let Some(replace) = params.replace {
+                        query_pairs.append_pair("replace", &replace.to_string());
+                    }
+                    if let Some(service_container) = params.service_container {
+                        query_pairs.append_pair("serviceContainer", &service_container.to_string());
+                    }
+                    if let Some(start) = params.start {
+                        query_pairs.append_pair("start", &start.to_string());
+                    }
+                    if let Some(static_i_ps) = params.static_i_ps {
+                        for value in static_i_ps {
+                            query_pairs.append_pair("staticIPs", &value.to_string());
+                        }
+                    }
+                    if let Some(static_ma_cs) = params.static_ma_cs {
+                        for value in static_ma_cs {
+                            query_pairs.append_pair("staticMACs", &value.to_string());
+                        }
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(userns) = params.userns {
+                        query_pairs.append_pair("userns", userns);
+                    }
+                    if let Some(wait) = params.wait {
+                        query_pairs.append_pair("wait", &wait.to_string());
+                    }
                 }
-                if let Some(network) = params.network {
-                    query_pairs.append_pair(
-                        "network",
-                        &network
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(no_hosts) = params.no_hosts {
-                    query_pairs.append_pair("noHosts", &no_hosts.to_string());
-                }
-                if let Some(no_trunc) = params.no_trunc {
-                    query_pairs.append_pair("noTrunc", &no_trunc.to_string());
-                }
-                if let Some(publish_ports) = params.publish_ports {
-                    query_pairs.append_pair(
-                        "publishPorts",
-                        &publish_ports
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(replace) = params.replace {
-                    query_pairs.append_pair("replace", &replace.to_string());
-                }
-                if let Some(service_container) = params.service_container {
-                    query_pairs.append_pair("serviceContainer", &service_container.to_string());
-                }
-                if let Some(start) = params.start {
-                    query_pairs.append_pair("start", &start.to_string());
-                }
-                if let Some(static_i_ps) = params.static_i_ps {
-                    query_pairs.append_pair(
-                        "staticIPs",
-                        &static_i_ps
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(static_ma_cs) = params.static_ma_cs {
-                    query_pairs.append_pair(
-                        "staticMACs",
-                        &static_ma_cs
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(userns) = params.userns {
-                    query_pairs.append_pair("userns", userns);
-                }
-                if let Some(wait) = params.wait {
-                    query_pairs.append_pair("wait", &wait.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/containers_compat.rs
+++ b/src/v4/apis/containers_compat.rs
@@ -11,47 +11,49 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageCommit<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/commit");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(container) = params.container {
-                    query_pairs.append_pair("container", container);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
+                request_path.push_str("/commit");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(container) = params.container {
+                        query_pairs.append_pair("container", container);
+                    }
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
+                    if let Some(comment) = params.comment {
+                        query_pairs.append_pair("comment", comment);
+                    }
+                    if let Some(author) = params.author {
+                        query_pairs.append_pair("author", author);
+                    }
+                    if let Some(pause) = params.pause {
+                        query_pairs.append_pair("pause", &pause.to_string());
+                    }
+                    if let Some(changes) = params.changes {
+                        query_pairs.append_pair("changes", changes);
+                    }
+                    if let Some(squash) = params.squash {
+                        query_pairs.append_pair("squash", &squash.to_string());
+                    }
                 }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
-                }
-                if let Some(comment) = params.comment {
-                    query_pairs.append_pair("comment", comment);
-                }
-                if let Some(author) = params.author {
-                    query_pairs.append_pair("author", author);
-                }
-                if let Some(pause) = params.pause {
-                    query_pairs.append_pair("pause", &pause.to_string());
-                }
-                if let Some(changes) = params.changes {
-                    query_pairs.append_pair("changes", changes);
-                }
-                if let Some(squash) = params.squash {
-                    query_pairs.append_pair("squash", &squash.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /containers/{name}
     /// Remove a container
@@ -60,33 +62,35 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerDelete>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(v) = params.v {
-                    query_pairs.append_pair("v", &v.to_string());
+                request_path.push_str("/containers/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                    if let Some(v) = params.v {
+                        query_pairs.append_pair("v", &v.to_string());
+                    }
+                    if let Some(link) = params.link {
+                        query_pairs.append_pair("link", &link.to_string());
+                    }
                 }
-                if let Some(link) = params.link {
-                    query_pairs.append_pair("link", &link.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/archive
     /// Get files from a container
@@ -96,25 +100,27 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerArchive<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/archive");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("path", params.path);
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/archive");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("path", params.path);
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/archive
     /// Put files into a container
@@ -125,34 +131,36 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         params: Option<super::super::params::PutContainerArchive<'a>>,
         request: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/archive");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("path", params.path);
-                if let Some(no_overwrite_dir_non_dir) = params.no_overwrite_dir_non_dir {
-                    query_pairs.append_pair("noOverwriteDirNonDir", no_overwrite_dir_non_dir);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(copy_uidgid) = params.copy_uidgid {
-                    query_pairs.append_pair("copyUIDGID", copy_uidgid);
+                request_path.push_str("/containers/{name}/archive");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("path", params.path);
+                    if let Some(no_overwrite_dir_non_dir) = params.no_overwrite_dir_non_dir {
+                        query_pairs.append_pair("noOverwriteDirNonDir", no_overwrite_dir_non_dir);
+                    }
+                    if let Some(copy_uidgid) = params.copy_uidgid {
+                        query_pairs.append_pair("copyUIDGID", copy_uidgid);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/attach
     /// Attach to a container
@@ -166,42 +174,44 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerAttach<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/attach");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(detach_keys) = params.detach_keys {
-                    query_pairs.append_pair("detachKeys", detach_keys);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(logs) = params.logs {
-                    query_pairs.append_pair("logs", &logs.to_string());
+                request_path.push_str("/containers/{name}/attach");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(detach_keys) = params.detach_keys {
+                        query_pairs.append_pair("detachKeys", detach_keys);
+                    }
+                    if let Some(logs) = params.logs {
+                        query_pairs.append_pair("logs", &logs.to_string());
+                    }
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(stdout) = params.stdout {
+                        query_pairs.append_pair("stdout", &stdout.to_string());
+                    }
+                    if let Some(stderr) = params.stderr {
+                        query_pairs.append_pair("stderr", &stderr.to_string());
+                    }
+                    if let Some(stdin) = params.stdin {
+                        query_pairs.append_pair("stdin", &stdin.to_string());
+                    }
                 }
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
-                }
-                if let Some(stdout) = params.stdout {
-                    query_pairs.append_pair("stdout", &stdout.to_string());
-                }
-                if let Some(stderr) = params.stderr {
-                    query_pairs.append_pair("stderr", &stderr.to_string());
-                }
-                if let Some(stdin) = params.stdin {
-                    query_pairs.append_pair("stdin", &stdin.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/export
     /// Export a container
@@ -210,21 +220,23 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/export");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/export");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/json
     /// Inspect container
@@ -234,27 +246,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerInspect>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(size) = params.size {
-                    query_pairs.append_pair("size", &size.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(size) = params.size {
+                        query_pairs.append_pair("size", &size.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/kill
     /// Kill container
@@ -264,30 +278,32 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerKill<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/kill");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(signal) = params.signal {
-                    query_pairs.append_pair("signal", signal);
+                request_path.push_str("/containers/{name}/kill");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(signal) = params.signal {
+                        query_pairs.append_pair("signal", signal);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/logs
     /// Get container logs
@@ -297,45 +313,47 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerLogs<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/logs");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(follow) = params.follow {
-                    query_pairs.append_pair("follow", &follow.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(stdout) = params.stdout {
-                    query_pairs.append_pair("stdout", &stdout.to_string());
+                request_path.push_str("/containers/{name}/logs");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(follow) = params.follow {
+                        query_pairs.append_pair("follow", &follow.to_string());
+                    }
+                    if let Some(stdout) = params.stdout {
+                        query_pairs.append_pair("stdout", &stdout.to_string());
+                    }
+                    if let Some(stderr) = params.stderr {
+                        query_pairs.append_pair("stderr", &stderr.to_string());
+                    }
+                    if let Some(since) = params.since {
+                        query_pairs.append_pair("since", since);
+                    }
+                    if let Some(until) = params.until {
+                        query_pairs.append_pair("until", until);
+                    }
+                    if let Some(timestamps) = params.timestamps {
+                        query_pairs.append_pair("timestamps", &timestamps.to_string());
+                    }
+                    if let Some(tail) = params.tail {
+                        query_pairs.append_pair("tail", tail);
+                    }
                 }
-                if let Some(stderr) = params.stderr {
-                    query_pairs.append_pair("stderr", &stderr.to_string());
-                }
-                if let Some(since) = params.since {
-                    query_pairs.append_pair("since", since);
-                }
-                if let Some(until) = params.until {
-                    query_pairs.append_pair("until", until);
-                }
-                if let Some(timestamps) = params.timestamps {
-                    query_pairs.append_pair("timestamps", &timestamps.to_string());
-                }
-                if let Some(tail) = params.tail {
-                    query_pairs.append_pair("tail", tail);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/pause
     /// Pause container
@@ -344,21 +362,23 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/pause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/pause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/rename
     /// Rename an existing container
@@ -368,25 +388,27 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerRename<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/rename");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("name", params.name);
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/rename");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("name", params.name);
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/resize
     /// Resize a container's TTY
@@ -396,33 +418,35 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerResize>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/resize");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(h) = params.h {
-                    query_pairs.append_pair("h", &h.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(w) = params.w {
-                    query_pairs.append_pair("w", &w.to_string());
+                request_path.push_str("/containers/{name}/resize");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(h) = params.h {
+                        query_pairs.append_pair("h", &h.to_string());
+                    }
+                    if let Some(w) = params.w {
+                        query_pairs.append_pair("w", &w.to_string());
+                    }
+                    if let Some(running) = params.running {
+                        query_pairs.append_pair("running", &running.to_string());
+                    }
                 }
-                if let Some(running) = params.running {
-                    query_pairs.append_pair("running", &running.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/restart
     /// Restart container
@@ -431,27 +455,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerRestart>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/restart");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", &t.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/{name}/restart");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", &t.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/start
     /// Start a container
@@ -460,27 +486,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStart<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/start");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(detach_keys) = params.detach_keys {
-                    query_pairs.append_pair("detachKeys", detach_keys);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/{name}/start");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(detach_keys) = params.detach_keys {
+                        query_pairs.append_pair("detachKeys", detach_keys);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/stats
     /// Get stats for a container
@@ -490,30 +518,32 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStats>,
     ) -> Pin<Box<dyn Future<Output = Result<serde_json::Value, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/stats");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(one_shot) = params.one_shot {
-                    query_pairs.append_pair("one-shot", &one_shot.to_string());
+                request_path.push_str("/containers/{name}/stats");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(one_shot) = params.one_shot {
+                        query_pairs.append_pair("one-shot", &one_shot.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/stop
     /// Stop a container
@@ -523,27 +553,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStop>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/stop");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", &t.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/{name}/stop");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", &t.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/top
     /// List processes running inside a container
@@ -552,27 +584,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerTop<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/top");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(ps_args) = params.ps_args {
-                    query_pairs.append_pair("ps_args", ps_args);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/{name}/top");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(ps_args) = params.ps_args {
+                        query_pairs.append_pair("ps_args", ps_args);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/unpause
     /// Unpause container
@@ -581,21 +615,23 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/unpause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/unpause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/wait
     /// Wait on a container
@@ -605,30 +641,32 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerWait<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/wait");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(condition) = params.condition {
-                    query_pairs.append_pair("condition", condition);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(interval) = params.interval {
-                    query_pairs.append_pair("interval", interval);
+                request_path.push_str("/containers/{name}/wait");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(condition) = params.condition {
+                        query_pairs.append_pair("condition", condition);
+                    }
+                    if let Some(interval) = params.interval {
+                        query_pairs.append_pair("interval", interval);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/create
     /// Create a container
@@ -637,29 +675,31 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         params: Option<super::super::params::ContainerCreate<'a>>,
         body: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(name) = params.name {
-                    query_pairs.append_pair("name", name);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&body)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(name) = params.name {
+                        query_pairs.append_pair("name", name);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&body)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /containers/json
     /// List containers
@@ -668,38 +708,40 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ContainerList<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(external) = params.external {
-                    query_pairs.append_pair("external", &external.to_string());
+                request_path.push_str("/containers/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(external) = params.external {
+                        query_pairs.append_pair("external", &external.to_string());
+                    }
+                    if let Some(limit) = params.limit {
+                        query_pairs.append_pair("limit", &limit.to_string());
+                    }
+                    if let Some(size) = params.size {
+                        query_pairs.append_pair("size", &size.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
                 }
-                if let Some(limit) = params.limit {
-                    query_pairs.append_pair("limit", &limit.to_string());
-                }
-                if let Some(size) = params.size {
-                    query_pairs.append_pair("size", &size.to_string());
-                }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/prune
     /// Delete stopped containers
@@ -708,26 +750,28 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ContainerPrune<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/archive
     /// Copy files from a container
@@ -737,27 +781,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerArchiveLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/archive");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("path", params.path);
-                if let Some(rename) = params.rename {
-                    query_pairs.append_pair("rename", rename);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/archive");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("path", params.path);
+                    if let Some(rename) = params.rename {
+                        query_pairs.append_pair("rename", rename);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/exec.rs
+++ b/src/v4/apis/exec.rs
@@ -12,24 +12,26 @@ pub trait Exec: HasConfig + Send + Sync {
         name: &'a str,
         control: super::super::models::ContainerExecLibpodBody,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/exec");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&control)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/exec");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&control)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/exec/{id}/json
     /// Inspect an exec instance
@@ -38,21 +40,23 @@ pub trait Exec: HasConfig + Send + Sync {
         &'a self,
         id: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/exec/{id}/json");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/exec/{id}/json");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/exec/{id}/resize
     /// Resize an exec instance
@@ -62,30 +66,32 @@ pub trait Exec: HasConfig + Send + Sync {
         id: &'a str,
         params: Option<super::super::params::ExecResizeLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/exec/{id}/resize");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(h) = params.h {
-                    query_pairs.append_pair("h", &h.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(w) = params.w {
-                    query_pairs.append_pair("w", &w.to_string());
+                request_path.push_str("/libpod/exec/{id}/resize");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(h) = params.h {
+                        query_pairs.append_pair("h", &h.to_string());
+                    }
+                    if let Some(w) = params.w {
+                        query_pairs.append_pair("w", &w.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/exec/{id}/start
     /// Start an exec instance
@@ -96,23 +102,25 @@ pub trait Exec: HasConfig + Send + Sync {
         id: &'a str,
         control: super::super::models::ExecStartLibpodBody,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/exec/{id}/start");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&control)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/exec/{id}/start");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&control)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/exec_compat.rs
+++ b/src/v4/apis/exec_compat.rs
@@ -12,24 +12,26 @@ pub trait ExecCompat: HasConfig + Send + Sync {
         name: &'a str,
         control: super::super::models::ContainerExecBody,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/exec");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&control)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/exec");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&control)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /exec/{id}/json
     /// Inspect an exec instance
@@ -38,21 +40,23 @@ pub trait ExecCompat: HasConfig + Send + Sync {
         &'a self,
         id: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/exec/{id}/json");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/exec/{id}/json");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /exec/{id}/resize
     /// Resize an exec instance
@@ -62,33 +66,35 @@ pub trait ExecCompat: HasConfig + Send + Sync {
         id: &'a str,
         params: Option<super::super::params::ExecResize>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/exec/{id}/resize");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(h) = params.h {
-                    query_pairs.append_pair("h", &h.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(w) = params.w {
-                    query_pairs.append_pair("w", &w.to_string());
+                request_path.push_str("/exec/{id}/resize");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(h) = params.h {
+                        query_pairs.append_pair("h", &h.to_string());
+                    }
+                    if let Some(w) = params.w {
+                        query_pairs.append_pair("w", &w.to_string());
+                    }
+                    if let Some(running) = params.running {
+                        query_pairs.append_pair("running", &running.to_string());
+                    }
                 }
-                if let Some(running) = params.running {
-                    query_pairs.append_pair("running", &running.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /exec/{id}/start
     /// Start an exec instance
@@ -98,23 +104,25 @@ pub trait ExecCompat: HasConfig + Send + Sync {
         id: &'a str,
         control: super::super::models::ExecStartBody,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/exec/{id}/start");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&control)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/exec/{id}/start");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&control)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/images.rs
+++ b/src/v4/apis/images.rs
@@ -17,144 +17,126 @@ pub trait Images: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/build");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(dockerfile) = params.dockerfile {
-                    query_pairs.append_pair("dockerfile", dockerfile);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", t);
+                request_path.push_str("/libpod/build");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(dockerfile) = params.dockerfile {
+                        query_pairs.append_pair("dockerfile", dockerfile);
+                    }
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", t);
+                    }
+                    if let Some(allplatforms) = params.allplatforms {
+                        query_pairs.append_pair("allplatforms", &allplatforms.to_string());
+                    }
+                    if let Some(extrahosts) = params.extrahosts {
+                        query_pairs.append_pair("extrahosts", extrahosts);
+                    }
+                    if let Some(remote) = params.remote {
+                        query_pairs.append_pair("remote", remote);
+                    }
+                    if let Some(q) = params.q {
+                        query_pairs.append_pair("q", &q.to_string());
+                    }
+                    if let Some(nocache) = params.nocache {
+                        query_pairs.append_pair("nocache", &nocache.to_string());
+                    }
+                    if let Some(cachefrom) = params.cachefrom {
+                        query_pairs.append_pair("cachefrom", cachefrom);
+                    }
+                    if let Some(pull) = params.pull {
+                        query_pairs.append_pair("pull", &pull.to_string());
+                    }
+                    if let Some(rm) = params.rm {
+                        query_pairs.append_pair("rm", &rm.to_string());
+                    }
+                    if let Some(forcerm) = params.forcerm {
+                        query_pairs.append_pair("forcerm", &forcerm.to_string());
+                    }
+                    if let Some(memory) = params.memory {
+                        query_pairs.append_pair("memory", &memory.to_string());
+                    }
+                    if let Some(memswap) = params.memswap {
+                        query_pairs.append_pair("memswap", &memswap.to_string());
+                    }
+                    if let Some(cpushares) = params.cpushares {
+                        query_pairs.append_pair("cpushares", &cpushares.to_string());
+                    }
+                    if let Some(cpusetcpus) = params.cpusetcpus {
+                        query_pairs.append_pair("cpusetcpus", cpusetcpus);
+                    }
+                    if let Some(cpuperiod) = params.cpuperiod {
+                        query_pairs.append_pair("cpuperiod", &cpuperiod.to_string());
+                    }
+                    if let Some(cpuquota) = params.cpuquota {
+                        query_pairs.append_pair("cpuquota", &cpuquota.to_string());
+                    }
+                    if let Some(buildargs) = params.buildargs {
+                        query_pairs.append_pair("buildargs", buildargs);
+                    }
+                    if let Some(shmsize) = params.shmsize {
+                        query_pairs.append_pair("shmsize", &shmsize.to_string());
+                    }
+                    if let Some(squash) = params.squash {
+                        query_pairs.append_pair("squash", &squash.to_string());
+                    }
+                    if let Some(labels) = params.labels {
+                        query_pairs.append_pair("labels", labels);
+                    }
+                    if let Some(layer_label) = params.layer_label {
+                        for value in layer_label {
+                            query_pairs.append_pair("layerLabel", &value.to_string());
+                        }
+                    }
+                    if let Some(layers) = params.layers {
+                        query_pairs.append_pair("layers", &layers.to_string());
+                    }
+                    if let Some(networkmode) = params.networkmode {
+                        query_pairs.append_pair("networkmode", networkmode);
+                    }
+                    if let Some(platform) = params.platform {
+                        query_pairs.append_pair("platform", platform);
+                    }
+                    if let Some(target) = params.target {
+                        query_pairs.append_pair("target", target);
+                    }
+                    if let Some(outputs) = params.outputs {
+                        query_pairs.append_pair("outputs", outputs);
+                    }
+                    if let Some(httpproxy) = params.httpproxy {
+                        query_pairs.append_pair("httpproxy", &httpproxy.to_string());
+                    }
+                    if let Some(unsetenv) = params.unsetenv {
+                        for value in unsetenv {
+                            query_pairs.append_pair("unsetenv", &value.to_string());
+                        }
+                    }
+                    if let Some(unsetlabel) = params.unsetlabel {
+                        for value in unsetlabel {
+                            query_pairs.append_pair("unsetlabel", &value.to_string());
+                        }
+                    }
+                    if let Some(volume) = params.volume {
+                        for value in volume {
+                            query_pairs.append_pair("volume", &value.to_string());
+                        }
+                    }
                 }
-                if let Some(allplatforms) = params.allplatforms {
-                    query_pairs.append_pair("allplatforms", &allplatforms.to_string());
-                }
-                if let Some(extrahosts) = params.extrahosts {
-                    query_pairs.append_pair("extrahosts", extrahosts);
-                }
-                if let Some(remote) = params.remote {
-                    query_pairs.append_pair("remote", remote);
-                }
-                if let Some(q) = params.q {
-                    query_pairs.append_pair("q", &q.to_string());
-                }
-                if let Some(nocache) = params.nocache {
-                    query_pairs.append_pair("nocache", &nocache.to_string());
-                }
-                if let Some(cachefrom) = params.cachefrom {
-                    query_pairs.append_pair("cachefrom", cachefrom);
-                }
-                if let Some(pull) = params.pull {
-                    query_pairs.append_pair("pull", &pull.to_string());
-                }
-                if let Some(rm) = params.rm {
-                    query_pairs.append_pair("rm", &rm.to_string());
-                }
-                if let Some(forcerm) = params.forcerm {
-                    query_pairs.append_pair("forcerm", &forcerm.to_string());
-                }
-                if let Some(memory) = params.memory {
-                    query_pairs.append_pair("memory", &memory.to_string());
-                }
-                if let Some(memswap) = params.memswap {
-                    query_pairs.append_pair("memswap", &memswap.to_string());
-                }
-                if let Some(cpushares) = params.cpushares {
-                    query_pairs.append_pair("cpushares", &cpushares.to_string());
-                }
-                if let Some(cpusetcpus) = params.cpusetcpus {
-                    query_pairs.append_pair("cpusetcpus", cpusetcpus);
-                }
-                if let Some(cpuperiod) = params.cpuperiod {
-                    query_pairs.append_pair("cpuperiod", &cpuperiod.to_string());
-                }
-                if let Some(cpuquota) = params.cpuquota {
-                    query_pairs.append_pair("cpuquota", &cpuquota.to_string());
-                }
-                if let Some(buildargs) = params.buildargs {
-                    query_pairs.append_pair("buildargs", buildargs);
-                }
-                if let Some(shmsize) = params.shmsize {
-                    query_pairs.append_pair("shmsize", &shmsize.to_string());
-                }
-                if let Some(squash) = params.squash {
-                    query_pairs.append_pair("squash", &squash.to_string());
-                }
-                if let Some(labels) = params.labels {
-                    query_pairs.append_pair("labels", labels);
-                }
-                if let Some(layer_label) = params.layer_label {
-                    query_pairs.append_pair(
-                        "layerLabel",
-                        &layer_label
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(layers) = params.layers {
-                    query_pairs.append_pair("layers", &layers.to_string());
-                }
-                if let Some(networkmode) = params.networkmode {
-                    query_pairs.append_pair("networkmode", networkmode);
-                }
-                if let Some(platform) = params.platform {
-                    query_pairs.append_pair("platform", platform);
-                }
-                if let Some(target) = params.target {
-                    query_pairs.append_pair("target", target);
-                }
-                if let Some(outputs) = params.outputs {
-                    query_pairs.append_pair("outputs", outputs);
-                }
-                if let Some(httpproxy) = params.httpproxy {
-                    query_pairs.append_pair("httpproxy", &httpproxy.to_string());
-                }
-                if let Some(unsetenv) = params.unsetenv {
-                    query_pairs.append_pair(
-                        "unsetenv",
-                        &unsetenv
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(unsetlabel) = params.unsetlabel {
-                    query_pairs.append_pair(
-                        "unsetlabel",
-                        &unsetlabel
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(volume) = params.volume {
-                    query_pairs.append_pair(
-                        "volume",
-                        &volume
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /libpod/images/{name}
     /// Remove an image from the local storage.
@@ -164,27 +146,29 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageDeleteLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/images/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/changes
     /// Report on changes to images's filesystem; adds, deletes or modifications.
@@ -198,30 +182,32 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageChangesLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/changes");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(parent) = params.parent {
-                    query_pairs.append_pair("parent", parent);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(diff_type) = params.diff_type {
-                    query_pairs.append_pair("diffType", diff_type);
+                request_path.push_str("/libpod/images/{name}/changes");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(parent) = params.parent {
+                        query_pairs.append_pair("parent", parent);
+                    }
+                    if let Some(diff_type) = params.diff_type {
+                        query_pairs.append_pair("diffType", diff_type);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/exists
     /// Image exists
@@ -230,21 +216,23 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/images/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/get
     /// Export an image
@@ -254,30 +242,32 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageGetLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/get");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(format) = params.format {
-                    query_pairs.append_pair("format", format);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(compress) = params.compress {
-                    query_pairs.append_pair("compress", &compress.to_string());
+                request_path.push_str("/libpod/images/{name}/get");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(format) = params.format {
+                        query_pairs.append_pair("format", format);
+                    }
+                    if let Some(compress) = params.compress {
+                        query_pairs.append_pair("compress", &compress.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/history
     /// History of an image
@@ -286,21 +276,23 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/history");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/images/{name}/history");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/json
     /// Inspect an image
@@ -309,21 +301,23 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/images/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/{name}/push
     /// Push Image
@@ -333,42 +327,44 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImagePushLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/push");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(destination) = params.destination {
-                    query_pairs.append_pair("destination", destination);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(force_compression_format) = params.force_compression_format {
-                    query_pairs.append_pair(
-                        "forceCompressionFormat",
-                        &force_compression_format.to_string(),
-                    );
+                request_path.push_str("/libpod/images/{name}/push");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(destination) = params.destination {
+                        query_pairs.append_pair("destination", destination);
+                    }
+                    if let Some(force_compression_format) = params.force_compression_format {
+                        query_pairs.append_pair(
+                            "forceCompressionFormat",
+                            &force_compression_format.to_string(),
+                        );
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(quiet) = params.quiet {
+                        query_pairs.append_pair("quiet", &quiet.to_string());
+                    }
+                    if let Some(x_registry_auth) = params.x_registry_auth {
+                        req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
+                    }
                 }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(quiet) = params.quiet {
-                    query_pairs.append_pair("quiet", &quiet.to_string());
-                }
-                if let Some(x_registry_auth) = params.x_registry_auth {
-                    req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/{name}/tag
     /// Tag an image
@@ -378,30 +374,32 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageTagLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/tag");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
+                request_path.push_str("/libpod/images/{name}/tag");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/tree
     /// Image tree
@@ -411,27 +409,29 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageTreeLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/tree");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(whatrequires) = params.whatrequires {
-                    query_pairs.append_pair("whatrequires", &whatrequires.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/images/{name}/tree");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(whatrequires) = params.whatrequires {
+                        query_pairs.append_pair("whatrequires", &whatrequires.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/{name}/untag
     /// Untag an image
@@ -441,30 +441,32 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageUntagLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/untag");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
+                request_path.push_str("/libpod/images/{name}/untag");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/export
     /// Export multiple images
@@ -473,46 +475,44 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageExportLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/export");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(format) = params.format {
-                    query_pairs.append_pair("format", format);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(references) = params.references {
-                    query_pairs.append_pair(
-                        "references",
-                        &references
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+                request_path.push_str("/libpod/images/export");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(format) = params.format {
+                        query_pairs.append_pair("format", format);
+                    }
+                    if let Some(references) = params.references {
+                        for value in references {
+                            query_pairs.append_pair("references", &value.to_string());
+                        }
+                    }
+                    if let Some(compress) = params.compress {
+                        query_pairs.append_pair("compress", &compress.to_string());
+                    }
+                    if let Some(oci_accept_uncompressed_layers) =
+                        params.oci_accept_uncompressed_layers
+                    {
+                        query_pairs.append_pair(
+                            "ociAcceptUncompressedLayers",
+                            &oci_accept_uncompressed_layers.to_string(),
+                        );
+                    }
                 }
-                if let Some(compress) = params.compress {
-                    query_pairs.append_pair("compress", &compress.to_string());
-                }
-                if let Some(oci_accept_uncompressed_layers) = params.oci_accept_uncompressed_layers
-                {
-                    query_pairs.append_pair(
-                        "ociAcceptUncompressedLayers",
-                        &oci_accept_uncompressed_layers.to_string(),
-                    );
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/import
     /// Import image
@@ -522,48 +522,45 @@ pub trait Images: HasConfig + Send + Sync {
         params: Option<super::super::params::ImageImportLibpod<'a>>,
         upload: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/import");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(changes) = params.changes {
-                    query_pairs.append_pair(
-                        "changes",
-                        &changes
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(message) = params.message {
-                    query_pairs.append_pair("message", message);
+                request_path.push_str("/libpod/images/import");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(changes) = params.changes {
+                        for value in changes {
+                            query_pairs.append_pair("changes", &value.to_string());
+                        }
+                    }
+                    if let Some(message) = params.message {
+                        query_pairs.append_pair("message", message);
+                    }
+                    if let Some(reference) = params.reference {
+                        query_pairs.append_pair("reference", reference);
+                    }
+                    if let Some(url) = params.url {
+                        query_pairs.append_pair("url", url);
+                    }
+                    if let Some(content_type) = params.content_type {
+                        req_builder = req_builder.header("Content-Type", content_type);
+                    }
                 }
-                if let Some(reference) = params.reference {
-                    query_pairs.append_pair("reference", reference);
-                }
-                if let Some(url) = params.url {
-                    query_pairs.append_pair("url", url);
-                }
-                if let Some(content_type) = params.content_type {
-                    req_builder = req_builder.header("Content-Type", content_type);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&upload)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&upload)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/images/json
     /// List Images
@@ -572,29 +569,31 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageListLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+                request_path.push_str("/libpod/images/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/load
     /// Load image
@@ -603,23 +602,25 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         upload: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/load");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&upload)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/images/load");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&upload)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/images/prune
     /// Prune unused images
@@ -628,32 +629,34 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImagePruneLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(external) = params.external {
-                    query_pairs.append_pair("external", &external.to_string());
+                request_path.push_str("/libpod/images/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(external) = params.external {
+                        query_pairs.append_pair("external", &external.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/pull
     /// Pull images
@@ -662,53 +665,55 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImagePullLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/pull");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(reference) = params.reference {
-                    query_pairs.append_pair("reference", reference);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(quiet) = params.quiet {
-                    query_pairs.append_pair("quiet", &quiet.to_string());
+                request_path.push_str("/libpod/images/pull");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(reference) = params.reference {
+                        query_pairs.append_pair("reference", reference);
+                    }
+                    if let Some(quiet) = params.quiet {
+                        query_pairs.append_pair("quiet", &quiet.to_string());
+                    }
+                    if let Some(compat_mode) = params.compat_mode {
+                        query_pairs.append_pair("compatMode", &compat_mode.to_string());
+                    }
+                    if let Some(arch) = params.arch {
+                        query_pairs.append_pair("Arch", arch);
+                    }
+                    if let Some(os) = params.os {
+                        query_pairs.append_pair("OS", os);
+                    }
+                    if let Some(variant) = params.variant {
+                        query_pairs.append_pair("Variant", variant);
+                    }
+                    if let Some(policy) = params.policy {
+                        query_pairs.append_pair("policy", policy);
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(all_tags) = params.all_tags {
+                        query_pairs.append_pair("allTags", &all_tags.to_string());
+                    }
+                    if let Some(x_registry_auth) = params.x_registry_auth {
+                        req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
+                    }
                 }
-                if let Some(compat_mode) = params.compat_mode {
-                    query_pairs.append_pair("compatMode", &compat_mode.to_string());
-                }
-                if let Some(arch) = params.arch {
-                    query_pairs.append_pair("Arch", arch);
-                }
-                if let Some(os) = params.os {
-                    query_pairs.append_pair("OS", os);
-                }
-                if let Some(variant) = params.variant {
-                    query_pairs.append_pair("Variant", variant);
-                }
-                if let Some(policy) = params.policy {
-                    query_pairs.append_pair("policy", policy);
-                }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(all_tags) = params.all_tags {
-                    query_pairs.append_pair("allTags", &all_tags.to_string());
-                }
-                if let Some(x_registry_auth) = params.x_registry_auth {
-                    req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /libpod/images/remove
     /// Remove one or more images from the storage.
@@ -717,45 +722,42 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageDeleteAllLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/remove");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(images) = params.images {
-                    query_pairs.append_pair(
-                        "images",
-                        &images
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+                request_path.push_str("/libpod/images/remove");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(images) = params.images {
+                        for value in images {
+                            query_pairs.append_pair("images", &value.to_string());
+                        }
+                    }
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                    if let Some(ignore) = params.ignore {
+                        query_pairs.append_pair("ignore", &ignore.to_string());
+                    }
+                    if let Some(lookup_manifest) = params.lookup_manifest {
+                        query_pairs.append_pair("lookupManifest", &lookup_manifest.to_string());
+                    }
                 }
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
-                }
-                if let Some(ignore) = params.ignore {
-                    query_pairs.append_pair("ignore", &ignore.to_string());
-                }
-                if let Some(lookup_manifest) = params.lookup_manifest {
-                    query_pairs.append_pair("lookupManifest", &lookup_manifest.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/scp/{name}
     /// Copy an image from one host to another
@@ -765,30 +767,32 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageScpLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/scp/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(destination) = params.destination {
-                    query_pairs.append_pair("destination", destination);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(quiet) = params.quiet {
-                    query_pairs.append_pair("quiet", &quiet.to_string());
+                request_path.push_str("/libpod/images/scp/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(destination) = params.destination {
+                        query_pairs.append_pair("destination", destination);
+                    }
+                    if let Some(quiet) = params.quiet {
+                        query_pairs.append_pair("quiet", &quiet.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/search
     /// Search images
@@ -797,37 +801,39 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageSearchLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/search");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(term) = params.term {
-                    query_pairs.append_pair("term", term);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(limit) = params.limit {
-                    query_pairs.append_pair("limit", &limit.to_string());
+                request_path.push_str("/libpod/images/search");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(term) = params.term {
+                        query_pairs.append_pair("term", term);
+                    }
+                    if let Some(limit) = params.limit {
+                        query_pairs.append_pair("limit", &limit.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(list_tags) = params.list_tags {
+                        query_pairs.append_pair("listTags", &list_tags.to_string());
+                    }
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(list_tags) = params.list_tags {
-                    query_pairs.append_pair("listTags", &list_tags.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/images_compat.rs
+++ b/src/v4/apis/images_compat.rs
@@ -13,104 +13,106 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         input_stream: String,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::ImageBuild200, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/build");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(dockerfile) = params.dockerfile {
-                    query_pairs.append_pair("dockerfile", dockerfile);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", t);
+                request_path.push_str("/build");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(dockerfile) = params.dockerfile {
+                        query_pairs.append_pair("dockerfile", dockerfile);
+                    }
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", t);
+                    }
+                    if let Some(extrahosts) = params.extrahosts {
+                        query_pairs.append_pair("extrahosts", extrahosts);
+                    }
+                    if let Some(remote) = params.remote {
+                        query_pairs.append_pair("remote", remote);
+                    }
+                    if let Some(q) = params.q {
+                        query_pairs.append_pair("q", &q.to_string());
+                    }
+                    if let Some(nocache) = params.nocache {
+                        query_pairs.append_pair("nocache", &nocache.to_string());
+                    }
+                    if let Some(cachefrom) = params.cachefrom {
+                        query_pairs.append_pair("cachefrom", cachefrom);
+                    }
+                    if let Some(pull) = params.pull {
+                        query_pairs.append_pair("pull", &pull.to_string());
+                    }
+                    if let Some(rm) = params.rm {
+                        query_pairs.append_pair("rm", &rm.to_string());
+                    }
+                    if let Some(forcerm) = params.forcerm {
+                        query_pairs.append_pair("forcerm", &forcerm.to_string());
+                    }
+                    if let Some(memory) = params.memory {
+                        query_pairs.append_pair("memory", &memory.to_string());
+                    }
+                    if let Some(memswap) = params.memswap {
+                        query_pairs.append_pair("memswap", &memswap.to_string());
+                    }
+                    if let Some(cpushares) = params.cpushares {
+                        query_pairs.append_pair("cpushares", &cpushares.to_string());
+                    }
+                    if let Some(cpusetcpus) = params.cpusetcpus {
+                        query_pairs.append_pair("cpusetcpus", cpusetcpus);
+                    }
+                    if let Some(cpuperiod) = params.cpuperiod {
+                        query_pairs.append_pair("cpuperiod", &cpuperiod.to_string());
+                    }
+                    if let Some(cpuquota) = params.cpuquota {
+                        query_pairs.append_pair("cpuquota", &cpuquota.to_string());
+                    }
+                    if let Some(buildargs) = params.buildargs {
+                        query_pairs.append_pair("buildargs", buildargs);
+                    }
+                    if let Some(shmsize) = params.shmsize {
+                        query_pairs.append_pair("shmsize", &shmsize.to_string());
+                    }
+                    if let Some(squash) = params.squash {
+                        query_pairs.append_pair("squash", &squash.to_string());
+                    }
+                    if let Some(labels) = params.labels {
+                        query_pairs.append_pair("labels", labels);
+                    }
+                    if let Some(networkmode) = params.networkmode {
+                        query_pairs.append_pair("networkmode", networkmode);
+                    }
+                    if let Some(platform) = params.platform {
+                        query_pairs.append_pair("platform", platform);
+                    }
+                    if let Some(target) = params.target {
+                        query_pairs.append_pair("target", target);
+                    }
+                    if let Some(outputs) = params.outputs {
+                        query_pairs.append_pair("outputs", outputs);
+                    }
+                    if let Some(content_type) = params.content_type {
+                        req_builder = req_builder.header("Content-Type", content_type);
+                    }
+                    if let Some(x_registry_config) = params.x_registry_config {
+                        req_builder = req_builder.header("X-Registry-Config", x_registry_config);
+                    }
                 }
-                if let Some(extrahosts) = params.extrahosts {
-                    query_pairs.append_pair("extrahosts", extrahosts);
-                }
-                if let Some(remote) = params.remote {
-                    query_pairs.append_pair("remote", remote);
-                }
-                if let Some(q) = params.q {
-                    query_pairs.append_pair("q", &q.to_string());
-                }
-                if let Some(nocache) = params.nocache {
-                    query_pairs.append_pair("nocache", &nocache.to_string());
-                }
-                if let Some(cachefrom) = params.cachefrom {
-                    query_pairs.append_pair("cachefrom", cachefrom);
-                }
-                if let Some(pull) = params.pull {
-                    query_pairs.append_pair("pull", &pull.to_string());
-                }
-                if let Some(rm) = params.rm {
-                    query_pairs.append_pair("rm", &rm.to_string());
-                }
-                if let Some(forcerm) = params.forcerm {
-                    query_pairs.append_pair("forcerm", &forcerm.to_string());
-                }
-                if let Some(memory) = params.memory {
-                    query_pairs.append_pair("memory", &memory.to_string());
-                }
-                if let Some(memswap) = params.memswap {
-                    query_pairs.append_pair("memswap", &memswap.to_string());
-                }
-                if let Some(cpushares) = params.cpushares {
-                    query_pairs.append_pair("cpushares", &cpushares.to_string());
-                }
-                if let Some(cpusetcpus) = params.cpusetcpus {
-                    query_pairs.append_pair("cpusetcpus", cpusetcpus);
-                }
-                if let Some(cpuperiod) = params.cpuperiod {
-                    query_pairs.append_pair("cpuperiod", &cpuperiod.to_string());
-                }
-                if let Some(cpuquota) = params.cpuquota {
-                    query_pairs.append_pair("cpuquota", &cpuquota.to_string());
-                }
-                if let Some(buildargs) = params.buildargs {
-                    query_pairs.append_pair("buildargs", buildargs);
-                }
-                if let Some(shmsize) = params.shmsize {
-                    query_pairs.append_pair("shmsize", &shmsize.to_string());
-                }
-                if let Some(squash) = params.squash {
-                    query_pairs.append_pair("squash", &squash.to_string());
-                }
-                if let Some(labels) = params.labels {
-                    query_pairs.append_pair("labels", labels);
-                }
-                if let Some(networkmode) = params.networkmode {
-                    query_pairs.append_pair("networkmode", networkmode);
-                }
-                if let Some(platform) = params.platform {
-                    query_pairs.append_pair("platform", platform);
-                }
-                if let Some(target) = params.target {
-                    query_pairs.append_pair("target", target);
-                }
-                if let Some(outputs) = params.outputs {
-                    query_pairs.append_pair("outputs", outputs);
-                }
-                if let Some(content_type) = params.content_type {
-                    req_builder = req_builder.header("Content-Type", content_type);
-                }
-                if let Some(x_registry_config) = params.x_registry_config {
-                    req_builder = req_builder.header("X-Registry-Config", x_registry_config);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&input_stream)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&input_stream)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// DELETE /images/{name}
     /// Remove Image
@@ -120,30 +122,32 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageDelete>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(noprune) = params.noprune {
-                    query_pairs.append_pair("noprune", &noprune.to_string());
+                request_path.push_str("/images/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                    if let Some(noprune) = params.noprune {
+                        query_pairs.append_pair("noprune", &noprune.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /images/{name}/get
     /// Export an image
@@ -152,21 +156,23 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}/get");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/images/{name}/get");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /images/{name}/history
     /// History of an image
@@ -175,21 +181,23 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}/history");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/images/{name}/history");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /images/{name}/json
     /// Inspect an image
@@ -198,21 +206,23 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/images/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /images/{name}/push
     /// Push Image
@@ -222,39 +232,41 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImagePush<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}/push");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+                request_path.push_str("/images/{name}/push");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(compress) = params.compress {
+                        query_pairs.append_pair("compress", &compress.to_string());
+                    }
+                    if let Some(destination) = params.destination {
+                        query_pairs.append_pair("destination", destination);
+                    }
+                    if let Some(x_registry_auth) = params.x_registry_auth {
+                        req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
+                    }
                 }
-                if let Some(compress) = params.compress {
-                    query_pairs.append_pair("compress", &compress.to_string());
-                }
-                if let Some(destination) = params.destination {
-                    query_pairs.append_pair("destination", destination);
-                }
-                if let Some(x_registry_auth) = params.x_registry_auth {
-                    req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /images/{name}/tag
     /// Tag an image
@@ -264,30 +276,32 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageTag<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}/tag");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
+                request_path.push_str("/images/{name}/tag");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /images/create
     /// Create an image
@@ -297,47 +311,49 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         params: Option<super::super::params::ImageCreate<'a>>,
         input_image: String,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(from_image) = params.from_image {
-                    query_pairs.append_pair("fromImage", from_image);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(from_src) = params.from_src {
-                    query_pairs.append_pair("fromSrc", from_src);
+                request_path.push_str("/images/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(from_image) = params.from_image {
+                        query_pairs.append_pair("fromImage", from_image);
+                    }
+                    if let Some(from_src) = params.from_src {
+                        query_pairs.append_pair("fromSrc", from_src);
+                    }
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
+                    if let Some(message) = params.message {
+                        query_pairs.append_pair("message", message);
+                    }
+                    if let Some(platform) = params.platform {
+                        query_pairs.append_pair("platform", platform);
+                    }
+                    if let Some(x_registry_auth) = params.x_registry_auth {
+                        req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
+                    }
                 }
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
-                }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
-                }
-                if let Some(message) = params.message {
-                    query_pairs.append_pair("message", message);
-                }
-                if let Some(platform) = params.platform {
-                    query_pairs.append_pair("platform", platform);
-                }
-                if let Some(x_registry_auth) = params.x_registry_auth {
-                    req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&input_image)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&input_image)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /images/get
     /// Export several images
@@ -346,24 +362,26 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageGetAll<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/get");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("names", params.names);
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/images/get");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("names", params.names);
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /images/json
     /// List Images
@@ -372,32 +390,34 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageList<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+                request_path.push_str("/images/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                    if let Some(digests) = params.digests {
+                        query_pairs.append_pair("digests", &digests.to_string());
+                    }
                 }
-                if let Some(digests) = params.digests {
-                    query_pairs.append_pair("digests", &digests.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /images/load
     /// Import image
@@ -407,29 +427,31 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         params: Option<super::super::params::ImageLoad>,
         request: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/load");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(quiet) = params.quiet {
-                    query_pairs.append_pair("quiet", &quiet.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/images/load");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(quiet) = params.quiet {
+                        query_pairs.append_pair("quiet", &quiet.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /images/prune
     /// Prune unused images
@@ -438,26 +460,28 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImagePrune<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/images/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /images/search
     /// Search images
@@ -466,37 +490,39 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageSearch<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/search");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(term) = params.term {
-                    query_pairs.append_pair("term", term);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(limit) = params.limit {
-                    query_pairs.append_pair("limit", &limit.to_string());
+                request_path.push_str("/images/search");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(term) = params.term {
+                        query_pairs.append_pair("term", term);
+                    }
+                    if let Some(limit) = params.limit {
+                        query_pairs.append_pair("limit", &limit.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(list_tags) = params.list_tags {
+                        query_pairs.append_pair("listTags", &list_tags.to_string());
+                    }
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(list_tags) = params.list_tags {
-                    query_pairs.append_pair("listTags", &list_tags.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/manifests.rs
+++ b/src/v4/apis/manifests.rs
@@ -12,34 +12,36 @@ pub trait Manifests: HasConfig + Send + Sync {
         params: Option<super::super::params::ManifestCreateLibpod<'a>>,
         options: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("name", params.name);
-                query_pairs.append_pair("images", params.images);
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(amend) = params.amend {
-                    query_pairs.append_pair("amend", &amend.to_string());
+                request_path.push_str("/libpod/manifests");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("name", params.name);
+                    query_pairs.append_pair("images", params.images);
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(amend) = params.amend {
+                        query_pairs.append_pair("amend", &amend.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&options)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&options)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// DELETE /libpod/manifests/{name}
     /// Delete manifest list
@@ -50,21 +52,23 @@ pub trait Manifests: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/manifests/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/manifests/{name}
     /// Modify manifest list
@@ -79,30 +83,32 @@ pub trait Manifests: HasConfig + Send + Sync {
         params: Option<super::super::params::ManifestModifyLibpod>,
         options: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&options)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/manifests/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&options)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/manifests/{name}/add
     /// Add image
@@ -114,24 +120,26 @@ pub trait Manifests: HasConfig + Send + Sync {
         name: &'a str,
         options: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}/add");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&options)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/manifests/{name}/add");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&options)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/manifests/{name}/exists
     /// Exists
@@ -142,21 +150,23 @@ pub trait Manifests: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/manifests/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/manifests/{name}/json
     /// Inspect
@@ -166,27 +176,29 @@ pub trait Manifests: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ManifestInspectLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/manifests/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/manifests/{name}/push
     /// Push manifest to registry
@@ -198,28 +210,30 @@ pub trait Manifests: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ManifestPushV3Libpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}/push");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("destination", params.destination);
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/manifests/{name}/push");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("destination", params.destination);
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/manifests/{name}/registry/{destination}
     /// Push manifest list to registry
@@ -232,49 +246,46 @@ pub trait Manifests: HasConfig + Send + Sync {
         destination: &'a str,
         params: Option<super::super::params::ManifestPushLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}/registry/{destination}");
-            request_path = request_path.replace("{name}", name);
-            request_path = request_path.replace("{destination}", destination);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(add_compression) = params.add_compression {
-                    query_pairs.append_pair(
-                        "addCompression",
-                        &add_compression
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(force_compression_format) = params.force_compression_format {
-                    query_pairs.append_pair(
-                        "forceCompressionFormat",
-                        &force_compression_format.to_string(),
-                    );
+                request_path.push_str("/libpod/manifests/{name}/registry/{destination}");
+                request_path = request_path.replace("{name}", name);
+                request_path = request_path.replace("{destination}", destination);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(add_compression) = params.add_compression {
+                        for value in add_compression {
+                            query_pairs.append_pair("addCompression", &value.to_string());
+                        }
+                    }
+                    if let Some(force_compression_format) = params.force_compression_format {
+                        query_pairs.append_pair(
+                            "forceCompressionFormat",
+                            &force_compression_format.to_string(),
+                        );
+                    }
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(quiet) = params.quiet {
+                        query_pairs.append_pair("quiet", &quiet.to_string());
+                    }
                 }
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
-                }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(quiet) = params.quiet {
-                    query_pairs.append_pair("quiet", &quiet.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/networks.rs
+++ b/src/v4/apis/networks.rs
@@ -12,27 +12,29 @@ pub trait Networks: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::NetworkDeleteLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/networks/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/networks/{name}/connect
     /// Connect container to network
@@ -42,24 +44,26 @@ pub trait Networks: HasConfig + Send + Sync {
         name: &'a str,
         create: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}/connect");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/{name}/connect");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/networks/{name}/disconnect
     /// Disconnect container from network
@@ -69,24 +73,26 @@ pub trait Networks: HasConfig + Send + Sync {
         name: &'a str,
         create: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}/disconnect");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/{name}/disconnect");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/networks/{name}/exists
     /// Network exists
@@ -95,21 +101,23 @@ pub trait Networks: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/networks/{name}/json
     /// Inspect a network
@@ -118,21 +126,23 @@ pub trait Networks: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/networks/{name}/update
     /// Update existing podman network
@@ -142,24 +152,26 @@ pub trait Networks: HasConfig + Send + Sync {
         name: &'a str,
         update: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}/update");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&update)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/{name}/update");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&update)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/networks/create
     /// Create network
@@ -168,23 +180,25 @@ pub trait Networks: HasConfig + Send + Sync {
         &'a self,
         create: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/networks/json
     /// List networks
@@ -194,26 +208,28 @@ pub trait Networks: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::NetworkListLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/networks/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/networks/prune
     /// Delete unused networks
@@ -222,25 +238,27 @@ pub trait Networks: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::NetworkPruneLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/networks/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/networks_compat.rs
+++ b/src/v4/apis/networks_compat.rs
@@ -11,26 +11,28 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::NetworkList<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/networks");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /networks/{name}
     /// Remove a network
@@ -39,21 +41,23 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/networks/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /networks/{name}
     /// Inspect a network
@@ -63,30 +67,32 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::NetworkInspect<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(verbose) = params.verbose {
-                    query_pairs.append_pair("verbose", &verbose.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(scope) = params.scope {
-                    query_pairs.append_pair("scope", scope);
+                request_path.push_str("/networks/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(verbose) = params.verbose {
+                        query_pairs.append_pair("verbose", &verbose.to_string());
+                    }
+                    if let Some(scope) = params.scope {
+                        query_pairs.append_pair("scope", scope);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /networks/{name}/connect
     /// Connect container to network
@@ -96,24 +102,26 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
         name: &'a str,
         create: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/{name}/connect");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/networks/{name}/connect");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /networks/{name}/disconnect
     /// Disconnect container from network
@@ -123,24 +131,26 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
         name: &'a str,
         create: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/{name}/disconnect");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/networks/{name}/disconnect");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /networks/create
     /// Create network
@@ -151,23 +161,25 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::NetworkCreate201, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/networks/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /networks/prune
     /// Delete unused networks
@@ -178,25 +190,27 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::NetworkPrune200, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/networks/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/pods.rs
+++ b/src/v4/apis/pods.rs
@@ -11,27 +11,29 @@ pub trait Pods: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::PodDeleteLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/pods/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/pods/{name}/exists
     /// Pod exists
@@ -40,21 +42,23 @@ pub trait Pods: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/pods/{name}/json
     /// Inspect pod
@@ -62,21 +66,23 @@ pub trait Pods: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/kill
     /// Kill a pod
@@ -85,27 +91,29 @@ pub trait Pods: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::PodKillLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/kill");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(signal) = params.signal {
-                    query_pairs.append_pair("signal", signal);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/pods/{name}/kill");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(signal) = params.signal {
+                        query_pairs.append_pair("signal", signal);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/pause
     /// Pause a pod
@@ -114,21 +122,23 @@ pub trait Pods: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/pause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/pause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/restart
     /// Restart a pod
@@ -136,21 +146,23 @@ pub trait Pods: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/restart");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/restart");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/start
     /// Start a pod
@@ -158,21 +170,23 @@ pub trait Pods: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/start");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/start");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/stop
     /// Stop a pod
@@ -181,27 +195,29 @@ pub trait Pods: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::PodStopLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/stop");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", &t.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/pods/{name}/stop");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", &t.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/pods/{name}/top
     /// List processes
@@ -211,33 +227,35 @@ pub trait Pods: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::PodTopLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/top");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(delay) = params.delay {
-                    query_pairs.append_pair("delay", &delay.to_string());
+                request_path.push_str("/libpod/pods/{name}/top");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(delay) = params.delay {
+                        query_pairs.append_pair("delay", &delay.to_string());
+                    }
+                    if let Some(ps_args) = params.ps_args {
+                        query_pairs.append_pair("ps_args", ps_args);
+                    }
                 }
-                if let Some(ps_args) = params.ps_args {
-                    query_pairs.append_pair("ps_args", ps_args);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/unpause
     /// Unpause a pod
@@ -245,21 +263,23 @@ pub trait Pods: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/unpause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/unpause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/create
     /// Create a pod
@@ -267,23 +287,25 @@ pub trait Pods: HasConfig + Send + Sync {
         &'a self,
         create: serde_json::Value,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/pods/json
     /// List pods
@@ -291,46 +313,50 @@ pub trait Pods: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::PodListLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/pods/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/prune
     /// Prune unused pods
     fn pod_prune_libpod<'a>(
         &'a self,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/pods/stats
     /// Statistics for one or more pods
@@ -339,35 +365,32 @@ pub trait Pods: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::PodStatsAllLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/stats");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(names_or_i_ds) = params.names_or_i_ds {
-                    query_pairs.append_pair(
-                        "namesOrIDs",
-                        &names_or_i_ds
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+                request_path.push_str("/libpod/pods/stats");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(names_or_i_ds) = params.names_or_i_ds {
+                        for value in names_or_i_ds {
+                            query_pairs.append_pair("namesOrIDs", &value.to_string());
+                        }
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/secrets.rs
+++ b/src/v4/apis/secrets.rs
@@ -11,27 +11,29 @@ pub trait Secrets: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::SecretDeleteLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/secrets/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/secrets/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/secrets/{name}/exists
     /// Secret exists
@@ -39,21 +41,23 @@ pub trait Secrets: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/secrets/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/secrets/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/secrets/{name}/json
     /// Inspect secret
@@ -62,27 +66,29 @@ pub trait Secrets: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::SecretInspectLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/secrets/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(showsecret) = params.showsecret {
-                    query_pairs.append_pair("showsecret", &showsecret.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/secrets/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(showsecret) = params.showsecret {
+                        query_pairs.append_pair("showsecret", &showsecret.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/secrets/create
     /// Create a secret
@@ -91,36 +97,38 @@ pub trait Secrets: HasConfig + Send + Sync {
         params: Option<super::super::params::SecretCreateLibpod<'a>>,
         request: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/secrets/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("name", params.name);
-                if let Some(driver) = params.driver {
-                    query_pairs.append_pair("driver", driver);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(driveropts) = params.driveropts {
-                    query_pairs.append_pair("driveropts", driveropts);
+                request_path.push_str("/libpod/secrets/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("name", params.name);
+                    if let Some(driver) = params.driver {
+                        query_pairs.append_pair("driver", driver);
+                    }
+                    if let Some(driveropts) = params.driveropts {
+                        query_pairs.append_pair("driveropts", driveropts);
+                    }
+                    if let Some(labels) = params.labels {
+                        query_pairs.append_pair("labels", labels);
+                    }
                 }
-                if let Some(labels) = params.labels {
-                    query_pairs.append_pair("labels", labels);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/secrets/json
     /// List secrets
@@ -129,25 +137,27 @@ pub trait Secrets: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::SecretListLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/secrets/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/secrets/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/secrets_compat.rs
+++ b/src/v4/apis/secrets_compat.rs
@@ -11,26 +11,28 @@ pub trait SecretsCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::SecretList<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/secrets");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/secrets");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /secrets/{name}
     /// Remove secret
@@ -38,21 +40,23 @@ pub trait SecretsCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/secrets/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/secrets/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /secrets/{name}
     /// Inspect secret
@@ -60,21 +64,23 @@ pub trait SecretsCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/secrets/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/secrets/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /secrets/create
     /// Create a secret
@@ -82,22 +88,24 @@ pub trait SecretsCompat: HasConfig + Send + Sync {
         &'a self,
         create: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/secrets/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/secrets/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/system.rs
+++ b/src/v4/apis/system.rs
@@ -11,35 +11,37 @@ pub trait System: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::SystemEventsLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/events");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(since) = params.since {
-                    query_pairs.append_pair("since", since);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(until) = params.until {
-                    query_pairs.append_pair("until", until);
+                request_path.push_str("/libpod/events");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(since) = params.since {
+                        query_pairs.append_pair("since", since);
+                    }
+                    if let Some(until) = params.until {
+                        query_pairs.append_pair("until", until);
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/info
     /// Get info
@@ -47,20 +49,22 @@ pub trait System: HasConfig + Send + Sync {
     fn system_info_libpod<'a>(
         &'a self,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/info");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/info");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/system/df
     /// Show disk usage
@@ -68,59 +72,65 @@ pub trait System: HasConfig + Send + Sync {
     fn system_data_usage_libpod<'a>(
         &'a self,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/system/df");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/system/df");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/system/prune
     /// Prune unused data
     fn system_prune_libpod<'a>(
         &'a self,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/system/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/system/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/version
     /// Component Version information
     fn system_version_libpod<'a>(
         &'a self,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/version");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/version");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/system_compat.rs
+++ b/src/v4/apis/system_compat.rs
@@ -10,23 +10,25 @@ pub trait SystemCompat: HasConfig + Send + Sync {
         &'a self,
         auth_config: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/auth");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&auth_config)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/auth");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&auth_config)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /events
     /// Get events
@@ -35,51 +37,55 @@ pub trait SystemCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::SystemEvents<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/events");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(since) = params.since {
-                    query_pairs.append_pair("since", since);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(until) = params.until {
-                    query_pairs.append_pair("until", until);
+                request_path.push_str("/events");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(since) = params.since {
+                        query_pairs.append_pair("since", since);
+                    }
+                    if let Some(until) = params.until {
+                        query_pairs.append_pair("until", until);
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /info
     /// Get info
     /// Returns information on the system and libpod configuration
     fn system_info<'a>(&'a self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/info");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/info");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/_ping
     /// Ping service
@@ -90,20 +96,22 @@ pub trait SystemCompat: HasConfig + Send + Sync {
     fn system_ping<'a>(
         &'a self,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/_ping");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/_ping");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /system/df
     /// Show disk usage
@@ -111,39 +119,43 @@ pub trait SystemCompat: HasConfig + Send + Sync {
     fn system_data_usage<'a>(
         &'a self,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/system/df");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/system/df");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /version
     /// Component Version information
     fn system_version<'a>(
         &'a self,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/version");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/version");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/volumes.rs
+++ b/src/v4/apis/volumes.rs
@@ -11,27 +11,29 @@ pub trait Volumes: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::VolumeDeleteLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/volumes/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/volumes/{name}/exists
     /// Volume exists
@@ -40,21 +42,23 @@ pub trait Volumes: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/volumes/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/volumes/{name}/json
     /// Inspect volume
@@ -62,21 +66,23 @@ pub trait Volumes: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/volumes/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/volumes/create
     /// Create a volume
@@ -84,23 +90,25 @@ pub trait Volumes: HasConfig + Send + Sync {
         &'a self,
         create: super::super::models::VolumeCreateOptions,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/volumes/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/volumes/json
     /// List volumes
@@ -109,26 +117,28 @@ pub trait Volumes: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::VolumeListLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/volumes/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/volumes/prune
     /// Prune volumes
@@ -136,25 +146,27 @@ pub trait Volumes: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::VolumePruneLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<()>, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/volumes/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v4/apis/volumes_compat.rs
+++ b/src/v4/apis/volumes_compat.rs
@@ -11,26 +11,28 @@ pub trait VolumesCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::VolumeList<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/volumes");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/volumes");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /volumes/{name}
     /// Remove volume
@@ -39,27 +41,29 @@ pub trait VolumesCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::VolumeDelete>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/volumes/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/volumes/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /volumes/{name}
     /// Inspect volume
@@ -67,21 +71,23 @@ pub trait VolumesCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/volumes/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/volumes/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /volumes/create
     /// Create a volume
@@ -89,23 +95,25 @@ pub trait VolumesCompat: HasConfig + Send + Sync {
         &'a self,
         create: (),
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/volumes/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/volumes/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /volumes/prune
     /// Prune volumes
@@ -113,25 +121,27 @@ pub trait VolumesCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::VolumePrune<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/volumes/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/volumes/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/containers.rs
+++ b/src/v5/apis/containers.rs
@@ -11,58 +11,55 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageCommitLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/commit");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("container", params.container);
-                if let Some(author) = params.author {
-                    query_pairs.append_pair("author", author);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(changes) = params.changes {
-                    query_pairs.append_pair(
-                        "changes",
-                        &changes
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+                request_path.push_str("/libpod/commit");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("container", params.container);
+                    if let Some(author) = params.author {
+                        query_pairs.append_pair("author", author);
+                    }
+                    if let Some(changes) = params.changes {
+                        for value in changes {
+                            query_pairs.append_pair("changes", &value.to_string());
+                        }
+                    }
+                    if let Some(comment) = params.comment {
+                        query_pairs.append_pair("comment", comment);
+                    }
+                    if let Some(format) = params.format {
+                        query_pairs.append_pair("format", format);
+                    }
+                    if let Some(pause) = params.pause {
+                        query_pairs.append_pair("pause", &pause.to_string());
+                    }
+                    if let Some(squash) = params.squash {
+                        query_pairs.append_pair("squash", &squash.to_string());
+                    }
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
                 }
-                if let Some(comment) = params.comment {
-                    query_pairs.append_pair("comment", comment);
-                }
-                if let Some(format) = params.format {
-                    query_pairs.append_pair("format", format);
-                }
-                if let Some(pause) = params.pause {
-                    query_pairs.append_pair("pause", &pause.to_string());
-                }
-                if let Some(squash) = params.squash {
-                    query_pairs.append_pair("squash", &squash.to_string());
-                }
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
-                }
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
-                }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /libpod/containers/{name}
     /// Delete container
@@ -78,39 +75,41 @@ pub trait Containers: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(depend) = params.depend {
-                    query_pairs.append_pair("depend", &depend.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+                request_path.push_str("/libpod/containers/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(depend) = params.depend {
+                        query_pairs.append_pair("depend", &depend.to_string());
+                    }
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                    if let Some(ignore) = params.ignore {
+                        query_pairs.append_pair("ignore", &ignore.to_string());
+                    }
+                    if let Some(timeout) = params.timeout {
+                        query_pairs.append_pair("timeout", &timeout.to_string());
+                    }
+                    if let Some(v) = params.v {
+                        query_pairs.append_pair("v", &v.to_string());
+                    }
                 }
-                if let Some(ignore) = params.ignore {
-                    query_pairs.append_pair("ignore", &ignore.to_string());
-                }
-                if let Some(timeout) = params.timeout {
-                    query_pairs.append_pair("timeout", &timeout.to_string());
-                }
-                if let Some(v) = params.v {
-                    query_pairs.append_pair("v", &v.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/archive
     /// Copy files into a container
@@ -121,31 +120,33 @@ pub trait Containers: HasConfig + Send + Sync {
         params: Option<super::super::params::PutContainerArchiveLibpod<'a>>,
         request: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/archive");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("path", params.path);
-                if let Some(pause) = params.pause {
-                    query_pairs.append_pair("pause", &pause.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/archive");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("path", params.path);
+                    if let Some(pause) = params.pause {
+                        query_pairs.append_pair("pause", &pause.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/attach
     /// Attach to a container
@@ -241,42 +242,44 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerAttachLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/attach");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(detach_keys) = params.detach_keys {
-                    query_pairs.append_pair("detachKeys", detach_keys);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(logs) = params.logs {
-                    query_pairs.append_pair("logs", &logs.to_string());
+                request_path.push_str("/libpod/containers/{name}/attach");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(detach_keys) = params.detach_keys {
+                        query_pairs.append_pair("detachKeys", detach_keys);
+                    }
+                    if let Some(logs) = params.logs {
+                        query_pairs.append_pair("logs", &logs.to_string());
+                    }
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(stdout) = params.stdout {
+                        query_pairs.append_pair("stdout", &stdout.to_string());
+                    }
+                    if let Some(stderr) = params.stderr {
+                        query_pairs.append_pair("stderr", &stderr.to_string());
+                    }
+                    if let Some(stdin) = params.stdin {
+                        query_pairs.append_pair("stdin", &stdin.to_string());
+                    }
                 }
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
-                }
-                if let Some(stdout) = params.stdout {
-                    query_pairs.append_pair("stdout", &stdout.to_string());
-                }
-                if let Some(stderr) = params.stderr {
-                    query_pairs.append_pair("stderr", &stderr.to_string());
-                }
-                if let Some(stdin) = params.stdin {
-                    query_pairs.append_pair("stdin", &stdin.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/changes
     /// Report on changes to container's filesystem; adds, deletes or modifications.
@@ -290,30 +293,32 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerChangesLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/changes");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(parent) = params.parent {
-                    query_pairs.append_pair("parent", parent);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(diff_type) = params.diff_type {
-                    query_pairs.append_pair("diffType", diff_type);
+                request_path.push_str("/libpod/containers/{name}/changes");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(parent) = params.parent {
+                        query_pairs.append_pair("parent", parent);
+                    }
+                    if let Some(diff_type) = params.diff_type {
+                        query_pairs.append_pair("diffType", diff_type);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/checkpoint
     /// Checkpoint a container
@@ -322,54 +327,56 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerCheckpointLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/checkpoint");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(keep) = params.keep {
-                    query_pairs.append_pair("keep", &keep.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(leave_running) = params.leave_running {
-                    query_pairs.append_pair("leaveRunning", &leave_running.to_string());
+                request_path.push_str("/libpod/containers/{name}/checkpoint");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(keep) = params.keep {
+                        query_pairs.append_pair("keep", &keep.to_string());
+                    }
+                    if let Some(leave_running) = params.leave_running {
+                        query_pairs.append_pair("leaveRunning", &leave_running.to_string());
+                    }
+                    if let Some(tcp_established) = params.tcp_established {
+                        query_pairs.append_pair("tcpEstablished", &tcp_established.to_string());
+                    }
+                    if let Some(export) = params.export {
+                        query_pairs.append_pair("export", &export.to_string());
+                    }
+                    if let Some(ignore_root_fs) = params.ignore_root_fs {
+                        query_pairs.append_pair("ignoreRootFS", &ignore_root_fs.to_string());
+                    }
+                    if let Some(ignore_volumes) = params.ignore_volumes {
+                        query_pairs.append_pair("ignoreVolumes", &ignore_volumes.to_string());
+                    }
+                    if let Some(pre_checkpoint) = params.pre_checkpoint {
+                        query_pairs.append_pair("preCheckpoint", &pre_checkpoint.to_string());
+                    }
+                    if let Some(with_previous) = params.with_previous {
+                        query_pairs.append_pair("withPrevious", &with_previous.to_string());
+                    }
+                    if let Some(file_locks) = params.file_locks {
+                        query_pairs.append_pair("fileLocks", &file_locks.to_string());
+                    }
+                    if let Some(print_stats) = params.print_stats {
+                        query_pairs.append_pair("printStats", &print_stats.to_string());
+                    }
                 }
-                if let Some(tcp_established) = params.tcp_established {
-                    query_pairs.append_pair("tcpEstablished", &tcp_established.to_string());
-                }
-                if let Some(export) = params.export {
-                    query_pairs.append_pair("export", &export.to_string());
-                }
-                if let Some(ignore_root_fs) = params.ignore_root_fs {
-                    query_pairs.append_pair("ignoreRootFS", &ignore_root_fs.to_string());
-                }
-                if let Some(ignore_volumes) = params.ignore_volumes {
-                    query_pairs.append_pair("ignoreVolumes", &ignore_volumes.to_string());
-                }
-                if let Some(pre_checkpoint) = params.pre_checkpoint {
-                    query_pairs.append_pair("preCheckpoint", &pre_checkpoint.to_string());
-                }
-                if let Some(with_previous) = params.with_previous {
-                    query_pairs.append_pair("withPrevious", &with_previous.to_string());
-                }
-                if let Some(file_locks) = params.file_locks {
-                    query_pairs.append_pair("fileLocks", &file_locks.to_string());
-                }
-                if let Some(print_stats) = params.print_stats {
-                    query_pairs.append_pair("printStats", &print_stats.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/exists
     /// Check if container exists
@@ -378,21 +385,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/export
     /// Export a container
@@ -400,22 +409,24 @@ pub trait Containers: HasConfig + Send + Sync {
     fn container_export_libpod<'a>(
         &'a self,
         name: &'a str,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/export");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+    ) -> Pin<Box<dyn futures::stream::Stream<Item = Result<bytes::Bytes, Error>> + 'a>> {
+        request::execute_request_stream(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/export");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        )
     }
     /// GET /libpod/containers/{name}/healthcheck
     /// Run a container's healthcheck
@@ -430,21 +441,23 @@ pub trait Containers: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/healthcheck");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/healthcheck");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/init
     /// Initialize a container
@@ -453,21 +466,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/init");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/init");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/json
     /// Inspect container
@@ -483,27 +498,29 @@ pub trait Containers: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(size) = params.size {
-                    query_pairs.append_pair("size", &size.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(size) = params.size {
+                        query_pairs.append_pair("size", &size.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/kill
     /// Kill container
@@ -513,27 +530,29 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerKillLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/kill");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(signal) = params.signal {
-                    query_pairs.append_pair("signal", signal);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/kill");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(signal) = params.signal {
+                        query_pairs.append_pair("signal", signal);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/logs
     /// Get container logs
@@ -545,45 +564,47 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerLogsLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/logs");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(follow) = params.follow {
-                    query_pairs.append_pair("follow", &follow.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(stdout) = params.stdout {
-                    query_pairs.append_pair("stdout", &stdout.to_string());
+                request_path.push_str("/libpod/containers/{name}/logs");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(follow) = params.follow {
+                        query_pairs.append_pair("follow", &follow.to_string());
+                    }
+                    if let Some(stdout) = params.stdout {
+                        query_pairs.append_pair("stdout", &stdout.to_string());
+                    }
+                    if let Some(stderr) = params.stderr {
+                        query_pairs.append_pair("stderr", &stderr.to_string());
+                    }
+                    if let Some(since) = params.since {
+                        query_pairs.append_pair("since", since);
+                    }
+                    if let Some(until) = params.until {
+                        query_pairs.append_pair("until", until);
+                    }
+                    if let Some(timestamps) = params.timestamps {
+                        query_pairs.append_pair("timestamps", &timestamps.to_string());
+                    }
+                    if let Some(tail) = params.tail {
+                        query_pairs.append_pair("tail", tail);
+                    }
                 }
-                if let Some(stderr) = params.stderr {
-                    query_pairs.append_pair("stderr", &stderr.to_string());
-                }
-                if let Some(since) = params.since {
-                    query_pairs.append_pair("since", since);
-                }
-                if let Some(until) = params.until {
-                    query_pairs.append_pair("until", until);
-                }
-                if let Some(timestamps) = params.timestamps {
-                    query_pairs.append_pair("timestamps", &timestamps.to_string());
-                }
-                if let Some(tail) = params.tail {
-                    query_pairs.append_pair("tail", tail);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/mount
     /// Mount a container
@@ -592,21 +613,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/mount");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/mount");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/pause
     /// Pause a container
@@ -615,21 +638,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/pause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/pause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/rename
     /// Rename an existing container
@@ -639,25 +664,27 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerRenameLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/rename");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("name", params.name);
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/rename");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("name", params.name);
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/resize
     /// Resize a container's TTY
@@ -667,30 +694,32 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerResizeLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<serde_json::Value, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/resize");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(h) = params.h {
-                    query_pairs.append_pair("h", &h.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(w) = params.w {
-                    query_pairs.append_pair("w", &w.to_string());
+                request_path.push_str("/libpod/containers/{name}/resize");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(h) = params.h {
+                        query_pairs.append_pair("h", &h.to_string());
+                    }
+                    if let Some(w) = params.w {
+                        query_pairs.append_pair("w", &w.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/restart
     /// Restart a container
@@ -699,27 +728,29 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerRestartLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/restart");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", &t.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/restart");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", &t.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/restore
     /// Restore a container
@@ -729,57 +760,59 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerRestoreLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/restore");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(name) = params.name {
-                    query_pairs.append_pair("name", name);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(keep) = params.keep {
-                    query_pairs.append_pair("keep", &keep.to_string());
+                request_path.push_str("/libpod/containers/{name}/restore");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(name) = params.name {
+                        query_pairs.append_pair("name", name);
+                    }
+                    if let Some(keep) = params.keep {
+                        query_pairs.append_pair("keep", &keep.to_string());
+                    }
+                    if let Some(tcp_established) = params.tcp_established {
+                        query_pairs.append_pair("tcpEstablished", &tcp_established.to_string());
+                    }
+                    if let Some(import) = params.import {
+                        query_pairs.append_pair("import", &import.to_string());
+                    }
+                    if let Some(ignore_root_fs) = params.ignore_root_fs {
+                        query_pairs.append_pair("ignoreRootFS", &ignore_root_fs.to_string());
+                    }
+                    if let Some(ignore_volumes) = params.ignore_volumes {
+                        query_pairs.append_pair("ignoreVolumes", &ignore_volumes.to_string());
+                    }
+                    if let Some(ignore_static_ip) = params.ignore_static_ip {
+                        query_pairs.append_pair("ignoreStaticIP", &ignore_static_ip.to_string());
+                    }
+                    if let Some(ignore_static_mac) = params.ignore_static_mac {
+                        query_pairs.append_pair("ignoreStaticMAC", &ignore_static_mac.to_string());
+                    }
+                    if let Some(file_locks) = params.file_locks {
+                        query_pairs.append_pair("fileLocks", &file_locks.to_string());
+                    }
+                    if let Some(print_stats) = params.print_stats {
+                        query_pairs.append_pair("printStats", &print_stats.to_string());
+                    }
+                    if let Some(pod) = params.pod {
+                        query_pairs.append_pair("pod", pod);
+                    }
                 }
-                if let Some(tcp_established) = params.tcp_established {
-                    query_pairs.append_pair("tcpEstablished", &tcp_established.to_string());
-                }
-                if let Some(import) = params.import {
-                    query_pairs.append_pair("import", &import.to_string());
-                }
-                if let Some(ignore_root_fs) = params.ignore_root_fs {
-                    query_pairs.append_pair("ignoreRootFS", &ignore_root_fs.to_string());
-                }
-                if let Some(ignore_volumes) = params.ignore_volumes {
-                    query_pairs.append_pair("ignoreVolumes", &ignore_volumes.to_string());
-                }
-                if let Some(ignore_static_ip) = params.ignore_static_ip {
-                    query_pairs.append_pair("ignoreStaticIP", &ignore_static_ip.to_string());
-                }
-                if let Some(ignore_static_mac) = params.ignore_static_mac {
-                    query_pairs.append_pair("ignoreStaticMAC", &ignore_static_mac.to_string());
-                }
-                if let Some(file_locks) = params.file_locks {
-                    query_pairs.append_pair("fileLocks", &file_locks.to_string());
-                }
-                if let Some(print_stats) = params.print_stats {
-                    query_pairs.append_pair("printStats", &print_stats.to_string());
-                }
-                if let Some(pod) = params.pod {
-                    query_pairs.append_pair("pod", pod);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/start
     /// Start a container
@@ -788,27 +821,29 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStartLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/start");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(detach_keys) = params.detach_keys {
-                    query_pairs.append_pair("detachKeys", detach_keys);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/start");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(detach_keys) = params.detach_keys {
+                        query_pairs.append_pair("detachKeys", detach_keys);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/stats
     /// Get stats for a container
@@ -818,27 +853,29 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStatsLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/stats");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/stats");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/stop
     /// Stop a container
@@ -847,30 +884,32 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStopLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/stop");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(timeout) = params.timeout {
-                    query_pairs.append_pair("timeout", &timeout.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(ignore) = params.ignore {
-                    query_pairs.append_pair("Ignore", &ignore.to_string());
+                request_path.push_str("/libpod/containers/{name}/stop");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(timeout) = params.timeout {
+                        query_pairs.append_pair("timeout", &timeout.to_string());
+                    }
+                    if let Some(ignore) = params.ignore {
+                        query_pairs.append_pair("Ignore", &ignore.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/top
     /// List processes
@@ -886,40 +925,37 @@ pub trait Containers: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/top");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(delay) = params.delay {
-                    query_pairs.append_pair("delay", &delay.to_string());
+                request_path.push_str("/libpod/containers/{name}/top");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(delay) = params.delay {
+                        query_pairs.append_pair("delay", &delay.to_string());
+                    }
+                    if let Some(ps_args) = params.ps_args {
+                        for value in ps_args {
+                            query_pairs.append_pair("ps_args", &value.to_string());
+                        }
+                    }
                 }
-                if let Some(ps_args) = params.ps_args {
-                    query_pairs.append_pair(
-                        "ps_args",
-                        &ps_args
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/unmount
     /// Unmount a container
@@ -928,21 +964,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/unmount");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/unmount");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/unpause
     /// Unpause Container
@@ -950,21 +988,23 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/unpause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/unpause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/update
     /// Update an existing containers cgroup configuration
@@ -975,33 +1015,35 @@ pub trait Containers: HasConfig + Send + Sync {
         params: Option<super::super::params::ContainerUpdateLibpod<'a>>,
         config: super::super::models::UpdateEntities,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/update");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(restart_policy) = params.restart_policy {
-                    query_pairs.append_pair("restartPolicy", restart_policy);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(restart_retries) = params.restart_retries {
-                    query_pairs.append_pair("restartRetries", &restart_retries.to_string());
+                request_path.push_str("/libpod/containers/{name}/update");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(restart_policy) = params.restart_policy {
+                        query_pairs.append_pair("restartPolicy", restart_policy);
+                    }
+                    if let Some(restart_retries) = params.restart_retries {
+                        query_pairs.append_pair("restartRetries", &restart_retries.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&config)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&config)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/{name}/wait
     /// Wait on a container
@@ -1011,37 +1053,34 @@ pub trait Containers: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerWaitLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<i32, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/wait");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(condition) = params.condition {
-                    query_pairs.append_pair(
-                        "condition",
-                        &condition
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(interval) = params.interval {
-                    query_pairs.append_pair("interval", interval);
+                request_path.push_str("/libpod/containers/{name}/wait");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(condition) = params.condition {
+                        for value in condition {
+                            query_pairs.append_pair("condition", &value.to_string());
+                        }
+                    }
+                    if let Some(interval) = params.interval {
+                        query_pairs.append_pair("interval", interval);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/create
     /// Create a container
@@ -1055,23 +1094,25 @@ pub trait Containers: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/json
     /// List containers
@@ -1086,44 +1127,46 @@ pub trait Containers: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(limit) = params.limit {
-                    query_pairs.append_pair("limit", &limit.to_string());
+                request_path.push_str("/libpod/containers/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(limit) = params.limit {
+                        query_pairs.append_pair("limit", &limit.to_string());
+                    }
+                    if let Some(namespace) = params.namespace {
+                        query_pairs.append_pair("namespace", &namespace.to_string());
+                    }
+                    if let Some(pod) = params.pod {
+                        query_pairs.append_pair("pod", &pod.to_string());
+                    }
+                    if let Some(size) = params.size {
+                        query_pairs.append_pair("size", &size.to_string());
+                    }
+                    if let Some(sync) = params.sync {
+                        query_pairs.append_pair("sync", &sync.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
                 }
-                if let Some(namespace) = params.namespace {
-                    query_pairs.append_pair("namespace", &namespace.to_string());
-                }
-                if let Some(pod) = params.pod {
-                    query_pairs.append_pair("pod", &pod.to_string());
-                }
-                if let Some(size) = params.size {
-                    query_pairs.append_pair("size", &size.to_string());
-                }
-                if let Some(sync) = params.sync {
-                    query_pairs.append_pair("sync", &sync.to_string());
-                }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/containers/prune
     /// Delete stopped containers
@@ -1139,26 +1182,28 @@ pub trait Containers: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/showmounted
     /// Show mounted containers
@@ -1172,20 +1217,22 @@ pub trait Containers: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/showmounted");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/showmounted");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/stats
     /// Get stats for one or more containers
@@ -1196,39 +1243,36 @@ pub trait Containers: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::ContainerStats, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/stats");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(containers) = params.containers {
-                    query_pairs.append_pair(
-                        "containers",
-                        &containers
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
+                request_path.push_str("/libpod/containers/stats");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(containers) = params.containers {
+                        for value in containers {
+                            query_pairs.append_pair("containers", &value.to_string());
+                        }
+                    }
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(interval) = params.interval {
+                        query_pairs.append_pair("interval", &interval.to_string());
+                    }
                 }
-                if let Some(interval) = params.interval {
-                    query_pairs.append_pair("interval", &interval.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/generate/{name}/systemd
     /// Generate Systemd Units
@@ -1244,94 +1288,76 @@ pub trait Containers: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/generate/{name}/systemd");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(use_name) = params.use_name {
-                    query_pairs.append_pair("useName", &use_name.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(new) = params.new {
-                    query_pairs.append_pair("new", &new.to_string());
+                request_path.push_str("/libpod/generate/{name}/systemd");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(use_name) = params.use_name {
+                        query_pairs.append_pair("useName", &use_name.to_string());
+                    }
+                    if let Some(new) = params.new {
+                        query_pairs.append_pair("new", &new.to_string());
+                    }
+                    if let Some(no_header) = params.no_header {
+                        query_pairs.append_pair("noHeader", &no_header.to_string());
+                    }
+                    if let Some(start_timeout) = params.start_timeout {
+                        query_pairs.append_pair("startTimeout", &start_timeout.to_string());
+                    }
+                    if let Some(stop_timeout) = params.stop_timeout {
+                        query_pairs.append_pair("stopTimeout", &stop_timeout.to_string());
+                    }
+                    if let Some(restart_policy) = params.restart_policy {
+                        query_pairs.append_pair("restartPolicy", restart_policy);
+                    }
+                    if let Some(container_prefix) = params.container_prefix {
+                        query_pairs.append_pair("containerPrefix", container_prefix);
+                    }
+                    if let Some(pod_prefix) = params.pod_prefix {
+                        query_pairs.append_pair("podPrefix", pod_prefix);
+                    }
+                    if let Some(separator) = params.separator {
+                        query_pairs.append_pair("separator", separator);
+                    }
+                    if let Some(restart_sec) = params.restart_sec {
+                        query_pairs.append_pair("restartSec", &restart_sec.to_string());
+                    }
+                    if let Some(wants) = params.wants {
+                        for value in wants {
+                            query_pairs.append_pair("wants", &value.to_string());
+                        }
+                    }
+                    if let Some(after) = params.after {
+                        for value in after {
+                            query_pairs.append_pair("after", &value.to_string());
+                        }
+                    }
+                    if let Some(requires) = params.requires {
+                        for value in requires {
+                            query_pairs.append_pair("requires", &value.to_string());
+                        }
+                    }
+                    if let Some(additional_env_variables) = params.additional_env_variables {
+                        for value in additional_env_variables {
+                            query_pairs.append_pair("additionalEnvVariables", &value.to_string());
+                        }
+                    }
                 }
-                if let Some(no_header) = params.no_header {
-                    query_pairs.append_pair("noHeader", &no_header.to_string());
-                }
-                if let Some(start_timeout) = params.start_timeout {
-                    query_pairs.append_pair("startTimeout", &start_timeout.to_string());
-                }
-                if let Some(stop_timeout) = params.stop_timeout {
-                    query_pairs.append_pair("stopTimeout", &stop_timeout.to_string());
-                }
-                if let Some(restart_policy) = params.restart_policy {
-                    query_pairs.append_pair("restartPolicy", restart_policy);
-                }
-                if let Some(container_prefix) = params.container_prefix {
-                    query_pairs.append_pair("containerPrefix", container_prefix);
-                }
-                if let Some(pod_prefix) = params.pod_prefix {
-                    query_pairs.append_pair("podPrefix", pod_prefix);
-                }
-                if let Some(separator) = params.separator {
-                    query_pairs.append_pair("separator", separator);
-                }
-                if let Some(restart_sec) = params.restart_sec {
-                    query_pairs.append_pair("restartSec", &restart_sec.to_string());
-                }
-                if let Some(wants) = params.wants {
-                    query_pairs.append_pair(
-                        "wants",
-                        &wants
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(after) = params.after {
-                    query_pairs.append_pair(
-                        "after",
-                        &after
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(requires) = params.requires {
-                    query_pairs.append_pair(
-                        "requires",
-                        &requires
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(additional_env_variables) = params.additional_env_variables {
-                    query_pairs.append_pair(
-                        "additionalEnvVariables",
-                        &additional_env_variables
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/generate/kube
     /// Generate a Kubernetes YAML file.
@@ -1340,47 +1366,43 @@ pub trait Containers: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::GenerateKubeLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/generate/kube");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair(
-                    "names",
-                    &params
-                        .names
-                        .iter()
-                        .map(|e| e.to_string())
-                        .collect::<Vec<_>>()
-                        .join(","),
-                );
-                if let Some(service) = params.service {
-                    query_pairs.append_pair("service", &service.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(r#type) = params.r#type {
-                    query_pairs.append_pair("type", r#type);
+                request_path.push_str("/libpod/generate/kube");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    for value in params.names {
+                        query_pairs.append_pair("names", &value.to_string());
+                    }
+                    if let Some(service) = params.service {
+                        query_pairs.append_pair("service", &service.to_string());
+                    }
+                    if let Some(r#type) = params.r#type {
+                        query_pairs.append_pair("type", r#type);
+                    }
+                    if let Some(replicas) = params.replicas {
+                        query_pairs.append_pair("replicas", &replicas.to_string());
+                    }
+                    if let Some(no_trunc) = params.no_trunc {
+                        query_pairs.append_pair("noTrunc", &no_trunc.to_string());
+                    }
+                    if let Some(podman_only) = params.podman_only {
+                        query_pairs.append_pair("podmanOnly", &podman_only.to_string());
+                    }
                 }
-                if let Some(replicas) = params.replicas {
-                    query_pairs.append_pair("replicas", &replicas.to_string());
-                }
-                if let Some(no_trunc) = params.no_trunc {
-                    query_pairs.append_pair("noTrunc", &no_trunc.to_string());
-                }
-                if let Some(podman_only) = params.podman_only {
-                    query_pairs.append_pair("podmanOnly", &podman_only.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/kube/apply
     /// Apply a podman workload or Kubernetes YAML file.
@@ -1390,41 +1412,43 @@ pub trait Containers: HasConfig + Send + Sync {
         params: Option<super::super::params::KubeApplyLibpod<'a>>,
         request: String,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/kube/apply");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(ca_cert_file) = params.ca_cert_file {
-                    query_pairs.append_pair("caCertFile", ca_cert_file);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(kube_config) = params.kube_config {
-                    query_pairs.append_pair("kubeConfig", kube_config);
+                request_path.push_str("/libpod/kube/apply");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(ca_cert_file) = params.ca_cert_file {
+                        query_pairs.append_pair("caCertFile", ca_cert_file);
+                    }
+                    if let Some(kube_config) = params.kube_config {
+                        query_pairs.append_pair("kubeConfig", kube_config);
+                    }
+                    if let Some(namespace) = params.namespace {
+                        query_pairs.append_pair("namespace", namespace);
+                    }
+                    if let Some(service) = params.service {
+                        query_pairs.append_pair("service", &service.to_string());
+                    }
+                    if let Some(file) = params.file {
+                        query_pairs.append_pair("file", file);
+                    }
                 }
-                if let Some(namespace) = params.namespace {
-                    query_pairs.append_pair("namespace", namespace);
-                }
-                if let Some(service) = params.service {
-                    query_pairs.append_pair("service", &service.to_string());
-                }
-                if let Some(file) = params.file {
-                    query_pairs.append_pair("file", file);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// DELETE /libpod/play/kube
     /// Remove resources created from kube play
@@ -1435,26 +1459,28 @@ pub trait Containers: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::PlayKubeReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/play/kube");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/play/kube");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/play/kube
     /// Play a Kubernetes YAML file.
@@ -1466,108 +1492,85 @@ pub trait Containers: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::PlayKubeReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/play/kube");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(annotations) = params.annotations {
-                    query_pairs.append_pair("annotations", annotations);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(log_driver) = params.log_driver {
-                    query_pairs.append_pair("logDriver", log_driver);
+                request_path.push_str("/libpod/play/kube");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(annotations) = params.annotations {
+                        query_pairs.append_pair("annotations", annotations);
+                    }
+                    if let Some(log_driver) = params.log_driver {
+                        query_pairs.append_pair("logDriver", log_driver);
+                    }
+                    if let Some(log_options) = params.log_options {
+                        for value in log_options {
+                            query_pairs.append_pair("logOptions", &value.to_string());
+                        }
+                    }
+                    if let Some(network) = params.network {
+                        for value in network {
+                            query_pairs.append_pair("network", &value.to_string());
+                        }
+                    }
+                    if let Some(no_hosts) = params.no_hosts {
+                        query_pairs.append_pair("noHosts", &no_hosts.to_string());
+                    }
+                    if let Some(no_trunc) = params.no_trunc {
+                        query_pairs.append_pair("noTrunc", &no_trunc.to_string());
+                    }
+                    if let Some(publish_ports) = params.publish_ports {
+                        for value in publish_ports {
+                            query_pairs.append_pair("publishPorts", &value.to_string());
+                        }
+                    }
+                    if let Some(publish_all_ports) = params.publish_all_ports {
+                        query_pairs.append_pair("publishAllPorts", &publish_all_ports.to_string());
+                    }
+                    if let Some(replace) = params.replace {
+                        query_pairs.append_pair("replace", &replace.to_string());
+                    }
+                    if let Some(service_container) = params.service_container {
+                        query_pairs.append_pair("serviceContainer", &service_container.to_string());
+                    }
+                    if let Some(start) = params.start {
+                        query_pairs.append_pair("start", &start.to_string());
+                    }
+                    if let Some(static_i_ps) = params.static_i_ps {
+                        for value in static_i_ps {
+                            query_pairs.append_pair("staticIPs", &value.to_string());
+                        }
+                    }
+                    if let Some(static_ma_cs) = params.static_ma_cs {
+                        for value in static_ma_cs {
+                            query_pairs.append_pair("staticMACs", &value.to_string());
+                        }
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(userns) = params.userns {
+                        query_pairs.append_pair("userns", userns);
+                    }
+                    if let Some(wait) = params.wait {
+                        query_pairs.append_pair("wait", &wait.to_string());
+                    }
                 }
-                if let Some(log_options) = params.log_options {
-                    query_pairs.append_pair(
-                        "logOptions",
-                        &log_options
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(network) = params.network {
-                    query_pairs.append_pair(
-                        "network",
-                        &network
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(no_hosts) = params.no_hosts {
-                    query_pairs.append_pair("noHosts", &no_hosts.to_string());
-                }
-                if let Some(no_trunc) = params.no_trunc {
-                    query_pairs.append_pair("noTrunc", &no_trunc.to_string());
-                }
-                if let Some(publish_ports) = params.publish_ports {
-                    query_pairs.append_pair(
-                        "publishPorts",
-                        &publish_ports
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(publish_all_ports) = params.publish_all_ports {
-                    query_pairs.append_pair("publishAllPorts", &publish_all_ports.to_string());
-                }
-                if let Some(replace) = params.replace {
-                    query_pairs.append_pair("replace", &replace.to_string());
-                }
-                if let Some(service_container) = params.service_container {
-                    query_pairs.append_pair("serviceContainer", &service_container.to_string());
-                }
-                if let Some(start) = params.start {
-                    query_pairs.append_pair("start", &start.to_string());
-                }
-                if let Some(static_i_ps) = params.static_i_ps {
-                    query_pairs.append_pair(
-                        "staticIPs",
-                        &static_i_ps
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(static_ma_cs) = params.static_ma_cs {
-                    query_pairs.append_pair(
-                        "staticMACs",
-                        &static_ma_cs
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(userns) = params.userns {
-                    query_pairs.append_pair("userns", userns);
-                }
-                if let Some(wait) = params.wait {
-                    query_pairs.append_pair("wait", &wait.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/containers_compat.rs
+++ b/src/v5/apis/containers_compat.rs
@@ -11,47 +11,49 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageCommit<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/commit");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(container) = params.container {
-                    query_pairs.append_pair("container", container);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
+                request_path.push_str("/commit");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(container) = params.container {
+                        query_pairs.append_pair("container", container);
+                    }
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
+                    if let Some(comment) = params.comment {
+                        query_pairs.append_pair("comment", comment);
+                    }
+                    if let Some(author) = params.author {
+                        query_pairs.append_pair("author", author);
+                    }
+                    if let Some(pause) = params.pause {
+                        query_pairs.append_pair("pause", &pause.to_string());
+                    }
+                    if let Some(changes) = params.changes {
+                        query_pairs.append_pair("changes", changes);
+                    }
+                    if let Some(squash) = params.squash {
+                        query_pairs.append_pair("squash", &squash.to_string());
+                    }
                 }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
-                }
-                if let Some(comment) = params.comment {
-                    query_pairs.append_pair("comment", comment);
-                }
-                if let Some(author) = params.author {
-                    query_pairs.append_pair("author", author);
-                }
-                if let Some(pause) = params.pause {
-                    query_pairs.append_pair("pause", &pause.to_string());
-                }
-                if let Some(changes) = params.changes {
-                    query_pairs.append_pair("changes", changes);
-                }
-                if let Some(squash) = params.squash {
-                    query_pairs.append_pair("squash", &squash.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /containers/{name}
     /// Remove a container
@@ -60,33 +62,35 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerDelete>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(v) = params.v {
-                    query_pairs.append_pair("v", &v.to_string());
+                request_path.push_str("/containers/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                    if let Some(v) = params.v {
+                        query_pairs.append_pair("v", &v.to_string());
+                    }
+                    if let Some(link) = params.link {
+                        query_pairs.append_pair("link", &link.to_string());
+                    }
                 }
-                if let Some(link) = params.link {
-                    query_pairs.append_pair("link", &link.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/archive
     /// Get files from a container
@@ -96,25 +100,27 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerArchive<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/archive");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("path", params.path);
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/archive");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("path", params.path);
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/archive
     /// Put files into a container
@@ -125,34 +131,36 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         params: Option<super::super::params::PutContainerArchive<'a>>,
         request: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/archive");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("path", params.path);
-                if let Some(no_overwrite_dir_non_dir) = params.no_overwrite_dir_non_dir {
-                    query_pairs.append_pair("noOverwriteDirNonDir", no_overwrite_dir_non_dir);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(copy_uidgid) = params.copy_uidgid {
-                    query_pairs.append_pair("copyUIDGID", copy_uidgid);
+                request_path.push_str("/containers/{name}/archive");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("path", params.path);
+                    if let Some(no_overwrite_dir_non_dir) = params.no_overwrite_dir_non_dir {
+                        query_pairs.append_pair("noOverwriteDirNonDir", no_overwrite_dir_non_dir);
+                    }
+                    if let Some(copy_uidgid) = params.copy_uidgid {
+                        query_pairs.append_pair("copyUIDGID", copy_uidgid);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/attach
     /// Attach to a container
@@ -166,42 +174,44 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerAttach<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/attach");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(detach_keys) = params.detach_keys {
-                    query_pairs.append_pair("detachKeys", detach_keys);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(logs) = params.logs {
-                    query_pairs.append_pair("logs", &logs.to_string());
+                request_path.push_str("/containers/{name}/attach");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(detach_keys) = params.detach_keys {
+                        query_pairs.append_pair("detachKeys", detach_keys);
+                    }
+                    if let Some(logs) = params.logs {
+                        query_pairs.append_pair("logs", &logs.to_string());
+                    }
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(stdout) = params.stdout {
+                        query_pairs.append_pair("stdout", &stdout.to_string());
+                    }
+                    if let Some(stderr) = params.stderr {
+                        query_pairs.append_pair("stderr", &stderr.to_string());
+                    }
+                    if let Some(stdin) = params.stdin {
+                        query_pairs.append_pair("stdin", &stdin.to_string());
+                    }
                 }
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
-                }
-                if let Some(stdout) = params.stdout {
-                    query_pairs.append_pair("stdout", &stdout.to_string());
-                }
-                if let Some(stderr) = params.stderr {
-                    query_pairs.append_pair("stderr", &stderr.to_string());
-                }
-                if let Some(stdin) = params.stdin {
-                    query_pairs.append_pair("stdin", &stdin.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/export
     /// Export a container
@@ -210,21 +220,23 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/export");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/export");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/json
     /// Inspect container
@@ -235,27 +247,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         params: Option<super::super::params::ContainerInspect>,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::ContainerJson, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(size) = params.size {
-                    query_pairs.append_pair("size", &size.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(size) = params.size {
+                        query_pairs.append_pair("size", &size.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/kill
     /// Kill container
@@ -265,30 +279,32 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerKill<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/kill");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(signal) = params.signal {
-                    query_pairs.append_pair("signal", signal);
+                request_path.push_str("/containers/{name}/kill");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(signal) = params.signal {
+                        query_pairs.append_pair("signal", signal);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/logs
     /// Get container logs
@@ -298,45 +314,47 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerLogs<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/logs");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(follow) = params.follow {
-                    query_pairs.append_pair("follow", &follow.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(stdout) = params.stdout {
-                    query_pairs.append_pair("stdout", &stdout.to_string());
+                request_path.push_str("/containers/{name}/logs");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(follow) = params.follow {
+                        query_pairs.append_pair("follow", &follow.to_string());
+                    }
+                    if let Some(stdout) = params.stdout {
+                        query_pairs.append_pair("stdout", &stdout.to_string());
+                    }
+                    if let Some(stderr) = params.stderr {
+                        query_pairs.append_pair("stderr", &stderr.to_string());
+                    }
+                    if let Some(since) = params.since {
+                        query_pairs.append_pair("since", since);
+                    }
+                    if let Some(until) = params.until {
+                        query_pairs.append_pair("until", until);
+                    }
+                    if let Some(timestamps) = params.timestamps {
+                        query_pairs.append_pair("timestamps", &timestamps.to_string());
+                    }
+                    if let Some(tail) = params.tail {
+                        query_pairs.append_pair("tail", tail);
+                    }
                 }
-                if let Some(stderr) = params.stderr {
-                    query_pairs.append_pair("stderr", &stderr.to_string());
-                }
-                if let Some(since) = params.since {
-                    query_pairs.append_pair("since", since);
-                }
-                if let Some(until) = params.until {
-                    query_pairs.append_pair("until", until);
-                }
-                if let Some(timestamps) = params.timestamps {
-                    query_pairs.append_pair("timestamps", &timestamps.to_string());
-                }
-                if let Some(tail) = params.tail {
-                    query_pairs.append_pair("tail", tail);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/pause
     /// Pause container
@@ -345,21 +363,23 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/pause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/pause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/rename
     /// Rename an existing container
@@ -369,25 +389,27 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerRename<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/rename");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("name", params.name);
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/rename");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("name", params.name);
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/resize
     /// Resize a container's TTY
@@ -397,33 +419,35 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerResize>,
     ) -> Pin<Box<dyn Future<Output = Result<serde_json::Value, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/resize");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(h) = params.h {
-                    query_pairs.append_pair("h", &h.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(w) = params.w {
-                    query_pairs.append_pair("w", &w.to_string());
+                request_path.push_str("/containers/{name}/resize");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(h) = params.h {
+                        query_pairs.append_pair("h", &h.to_string());
+                    }
+                    if let Some(w) = params.w {
+                        query_pairs.append_pair("w", &w.to_string());
+                    }
+                    if let Some(running) = params.running {
+                        query_pairs.append_pair("running", &running.to_string());
+                    }
                 }
-                if let Some(running) = params.running {
-                    query_pairs.append_pair("running", &running.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/restart
     /// Restart container
@@ -432,27 +456,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerRestart>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/restart");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", &t.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/{name}/restart");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", &t.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/start
     /// Start a container
@@ -461,27 +487,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStart<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/start");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(detach_keys) = params.detach_keys {
-                    query_pairs.append_pair("detachKeys", detach_keys);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/{name}/start");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(detach_keys) = params.detach_keys {
+                        query_pairs.append_pair("detachKeys", detach_keys);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/stats
     /// Get stats for a container
@@ -491,30 +519,32 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStats>,
     ) -> Pin<Box<dyn Future<Output = Result<serde_json::Value, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/stats");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(one_shot) = params.one_shot {
-                    query_pairs.append_pair("one-shot", &one_shot.to_string());
+                request_path.push_str("/containers/{name}/stats");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(one_shot) = params.one_shot {
+                        query_pairs.append_pair("one-shot", &one_shot.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/stop
     /// Stop a container
@@ -524,27 +554,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerStop>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/stop");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", &t.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/{name}/stop");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", &t.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /containers/{name}/top
     /// List processes running inside a container
@@ -559,27 +591,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/top");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(ps_args) = params.ps_args {
-                    query_pairs.append_pair("ps_args", ps_args);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/{name}/top");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(ps_args) = params.ps_args {
+                        query_pairs.append_pair("ps_args", ps_args);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/unpause
     /// Unpause container
@@ -588,21 +622,23 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/unpause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/unpause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/update
     /// Update configuration of an existing container
@@ -612,24 +648,26 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         resources: super::super::models::UpdateConfig,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/update");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&resources)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/update");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&resources)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /containers/{name}/wait
     /// Wait on a container
@@ -645,30 +683,32 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/wait");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(condition) = params.condition {
-                    query_pairs.append_pair("condition", condition);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(interval) = params.interval {
-                    query_pairs.append_pair("interval", interval);
+                request_path.push_str("/containers/{name}/wait");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(condition) = params.condition {
+                        query_pairs.append_pair("condition", condition);
+                    }
+                    if let Some(interval) = params.interval {
+                        query_pairs.append_pair("interval", interval);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/create
     /// Create a container
@@ -683,29 +723,31 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(name) = params.name {
-                    query_pairs.append_pair("name", name);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&body)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(name) = params.name {
+                        query_pairs.append_pair("name", name);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&body)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /containers/json
     /// List containers
@@ -716,38 +758,40 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<Vec<super::super::models::Container>, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(external) = params.external {
-                    query_pairs.append_pair("external", &external.to_string());
+                request_path.push_str("/containers/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(external) = params.external {
+                        query_pairs.append_pair("external", &external.to_string());
+                    }
+                    if let Some(limit) = params.limit {
+                        query_pairs.append_pair("limit", &limit.to_string());
+                    }
+                    if let Some(size) = params.size {
+                        query_pairs.append_pair("size", &size.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
                 }
-                if let Some(limit) = params.limit {
-                    query_pairs.append_pair("limit", &limit.to_string());
-                }
-                if let Some(size) = params.size {
-                    query_pairs.append_pair("size", &size.to_string());
-                }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /containers/prune
     /// Delete stopped containers
@@ -762,26 +806,28 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/containers/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/containers/{name}/archive
     /// Copy files from a container
@@ -791,27 +837,29 @@ pub trait ContainersCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ContainerArchiveLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/archive");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("path", params.path);
-                if let Some(rename) = params.rename {
-                    query_pairs.append_pair("rename", rename);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/containers/{name}/archive");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("path", params.path);
+                    if let Some(rename) = params.rename {
+                        query_pairs.append_pair("rename", rename);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/exec.rs
+++ b/src/v5/apis/exec.rs
@@ -12,24 +12,26 @@ pub trait Exec: HasConfig + Send + Sync {
         name: &'a str,
         control: super::super::models::ContainerExecLibpodBody,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/containers/{name}/exec");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&control)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/containers/{name}/exec");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&control)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/exec/{id}/json
     /// Inspect an exec instance
@@ -38,21 +40,23 @@ pub trait Exec: HasConfig + Send + Sync {
         &'a self,
         id: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/exec/{id}/json");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/exec/{id}/json");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/exec/{id}/resize
     /// Resize an exec instance
@@ -62,30 +66,32 @@ pub trait Exec: HasConfig + Send + Sync {
         id: &'a str,
         params: Option<super::super::params::ExecResizeLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/exec/{id}/resize");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(h) = params.h {
-                    query_pairs.append_pair("h", &h.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(w) = params.w {
-                    query_pairs.append_pair("w", &w.to_string());
+                request_path.push_str("/libpod/exec/{id}/resize");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(h) = params.h {
+                        query_pairs.append_pair("h", &h.to_string());
+                    }
+                    if let Some(w) = params.w {
+                        query_pairs.append_pair("w", &w.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/exec/{id}/start
     /// Start an exec instance
@@ -96,23 +102,25 @@ pub trait Exec: HasConfig + Send + Sync {
         id: &'a str,
         control: super::super::models::ExecStartLibpodBody,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/exec/{id}/start");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&control)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/exec/{id}/start");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&control)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/exec_compat.rs
+++ b/src/v5/apis/exec_compat.rs
@@ -12,24 +12,26 @@ pub trait ExecCompat: HasConfig + Send + Sync {
         name: &'a str,
         control: super::super::models::ContainerExecBody,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/containers/{name}/exec");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&control)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/containers/{name}/exec");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&control)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /exec/{id}/json
     /// Inspect an exec instance
@@ -44,21 +46,23 @@ pub trait ExecCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/exec/{id}/json");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/exec/{id}/json");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /exec/{id}/resize
     /// Resize an exec instance
@@ -68,33 +72,35 @@ pub trait ExecCompat: HasConfig + Send + Sync {
         id: &'a str,
         params: Option<super::super::params::ExecResize>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/exec/{id}/resize");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(h) = params.h {
-                    query_pairs.append_pair("h", &h.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(w) = params.w {
-                    query_pairs.append_pair("w", &w.to_string());
+                request_path.push_str("/exec/{id}/resize");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(h) = params.h {
+                        query_pairs.append_pair("h", &h.to_string());
+                    }
+                    if let Some(w) = params.w {
+                        query_pairs.append_pair("w", &w.to_string());
+                    }
+                    if let Some(running) = params.running {
+                        query_pairs.append_pair("running", &running.to_string());
+                    }
                 }
-                if let Some(running) = params.running {
-                    query_pairs.append_pair("running", &running.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /exec/{id}/start
     /// Start an exec instance
@@ -104,23 +110,25 @@ pub trait ExecCompat: HasConfig + Send + Sync {
         id: &'a str,
         control: super::super::models::ExecStartBody,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/exec/{id}/start");
-            request_path = request_path.replace("{id}", id);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&control)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/exec/{id}/start");
+                request_path = request_path.replace("{id}", id);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&control)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/images.rs
+++ b/src/v5/apis/images.rs
@@ -17,144 +17,126 @@ pub trait Images: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/build");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(dockerfile) = params.dockerfile {
-                    query_pairs.append_pair("dockerfile", dockerfile);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", t);
+                request_path.push_str("/libpod/build");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(dockerfile) = params.dockerfile {
+                        query_pairs.append_pair("dockerfile", dockerfile);
+                    }
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", t);
+                    }
+                    if let Some(allplatforms) = params.allplatforms {
+                        query_pairs.append_pair("allplatforms", &allplatforms.to_string());
+                    }
+                    if let Some(extrahosts) = params.extrahosts {
+                        query_pairs.append_pair("extrahosts", extrahosts);
+                    }
+                    if let Some(remote) = params.remote {
+                        query_pairs.append_pair("remote", remote);
+                    }
+                    if let Some(q) = params.q {
+                        query_pairs.append_pair("q", &q.to_string());
+                    }
+                    if let Some(nocache) = params.nocache {
+                        query_pairs.append_pair("nocache", &nocache.to_string());
+                    }
+                    if let Some(cachefrom) = params.cachefrom {
+                        query_pairs.append_pair("cachefrom", cachefrom);
+                    }
+                    if let Some(pull) = params.pull {
+                        query_pairs.append_pair("pull", &pull.to_string());
+                    }
+                    if let Some(rm) = params.rm {
+                        query_pairs.append_pair("rm", &rm.to_string());
+                    }
+                    if let Some(forcerm) = params.forcerm {
+                        query_pairs.append_pair("forcerm", &forcerm.to_string());
+                    }
+                    if let Some(memory) = params.memory {
+                        query_pairs.append_pair("memory", &memory.to_string());
+                    }
+                    if let Some(memswap) = params.memswap {
+                        query_pairs.append_pair("memswap", &memswap.to_string());
+                    }
+                    if let Some(cpushares) = params.cpushares {
+                        query_pairs.append_pair("cpushares", &cpushares.to_string());
+                    }
+                    if let Some(cpusetcpus) = params.cpusetcpus {
+                        query_pairs.append_pair("cpusetcpus", cpusetcpus);
+                    }
+                    if let Some(cpuperiod) = params.cpuperiod {
+                        query_pairs.append_pair("cpuperiod", &cpuperiod.to_string());
+                    }
+                    if let Some(cpuquota) = params.cpuquota {
+                        query_pairs.append_pair("cpuquota", &cpuquota.to_string());
+                    }
+                    if let Some(buildargs) = params.buildargs {
+                        query_pairs.append_pair("buildargs", buildargs);
+                    }
+                    if let Some(shmsize) = params.shmsize {
+                        query_pairs.append_pair("shmsize", &shmsize.to_string());
+                    }
+                    if let Some(squash) = params.squash {
+                        query_pairs.append_pair("squash", &squash.to_string());
+                    }
+                    if let Some(labels) = params.labels {
+                        query_pairs.append_pair("labels", labels);
+                    }
+                    if let Some(layer_label) = params.layer_label {
+                        for value in layer_label {
+                            query_pairs.append_pair("layerLabel", &value.to_string());
+                        }
+                    }
+                    if let Some(layers) = params.layers {
+                        query_pairs.append_pair("layers", &layers.to_string());
+                    }
+                    if let Some(networkmode) = params.networkmode {
+                        query_pairs.append_pair("networkmode", networkmode);
+                    }
+                    if let Some(platform) = params.platform {
+                        query_pairs.append_pair("platform", platform);
+                    }
+                    if let Some(target) = params.target {
+                        query_pairs.append_pair("target", target);
+                    }
+                    if let Some(outputs) = params.outputs {
+                        query_pairs.append_pair("outputs", outputs);
+                    }
+                    if let Some(httpproxy) = params.httpproxy {
+                        query_pairs.append_pair("httpproxy", &httpproxy.to_string());
+                    }
+                    if let Some(unsetenv) = params.unsetenv {
+                        for value in unsetenv {
+                            query_pairs.append_pair("unsetenv", &value.to_string());
+                        }
+                    }
+                    if let Some(unsetlabel) = params.unsetlabel {
+                        for value in unsetlabel {
+                            query_pairs.append_pair("unsetlabel", &value.to_string());
+                        }
+                    }
+                    if let Some(volume) = params.volume {
+                        for value in volume {
+                            query_pairs.append_pair("volume", &value.to_string());
+                        }
+                    }
                 }
-                if let Some(allplatforms) = params.allplatforms {
-                    query_pairs.append_pair("allplatforms", &allplatforms.to_string());
-                }
-                if let Some(extrahosts) = params.extrahosts {
-                    query_pairs.append_pair("extrahosts", extrahosts);
-                }
-                if let Some(remote) = params.remote {
-                    query_pairs.append_pair("remote", remote);
-                }
-                if let Some(q) = params.q {
-                    query_pairs.append_pair("q", &q.to_string());
-                }
-                if let Some(nocache) = params.nocache {
-                    query_pairs.append_pair("nocache", &nocache.to_string());
-                }
-                if let Some(cachefrom) = params.cachefrom {
-                    query_pairs.append_pair("cachefrom", cachefrom);
-                }
-                if let Some(pull) = params.pull {
-                    query_pairs.append_pair("pull", &pull.to_string());
-                }
-                if let Some(rm) = params.rm {
-                    query_pairs.append_pair("rm", &rm.to_string());
-                }
-                if let Some(forcerm) = params.forcerm {
-                    query_pairs.append_pair("forcerm", &forcerm.to_string());
-                }
-                if let Some(memory) = params.memory {
-                    query_pairs.append_pair("memory", &memory.to_string());
-                }
-                if let Some(memswap) = params.memswap {
-                    query_pairs.append_pair("memswap", &memswap.to_string());
-                }
-                if let Some(cpushares) = params.cpushares {
-                    query_pairs.append_pair("cpushares", &cpushares.to_string());
-                }
-                if let Some(cpusetcpus) = params.cpusetcpus {
-                    query_pairs.append_pair("cpusetcpus", cpusetcpus);
-                }
-                if let Some(cpuperiod) = params.cpuperiod {
-                    query_pairs.append_pair("cpuperiod", &cpuperiod.to_string());
-                }
-                if let Some(cpuquota) = params.cpuquota {
-                    query_pairs.append_pair("cpuquota", &cpuquota.to_string());
-                }
-                if let Some(buildargs) = params.buildargs {
-                    query_pairs.append_pair("buildargs", buildargs);
-                }
-                if let Some(shmsize) = params.shmsize {
-                    query_pairs.append_pair("shmsize", &shmsize.to_string());
-                }
-                if let Some(squash) = params.squash {
-                    query_pairs.append_pair("squash", &squash.to_string());
-                }
-                if let Some(labels) = params.labels {
-                    query_pairs.append_pair("labels", labels);
-                }
-                if let Some(layer_label) = params.layer_label {
-                    query_pairs.append_pair(
-                        "layerLabel",
-                        &layer_label
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(layers) = params.layers {
-                    query_pairs.append_pair("layers", &layers.to_string());
-                }
-                if let Some(networkmode) = params.networkmode {
-                    query_pairs.append_pair("networkmode", networkmode);
-                }
-                if let Some(platform) = params.platform {
-                    query_pairs.append_pair("platform", platform);
-                }
-                if let Some(target) = params.target {
-                    query_pairs.append_pair("target", target);
-                }
-                if let Some(outputs) = params.outputs {
-                    query_pairs.append_pair("outputs", outputs);
-                }
-                if let Some(httpproxy) = params.httpproxy {
-                    query_pairs.append_pair("httpproxy", &httpproxy.to_string());
-                }
-                if let Some(unsetenv) = params.unsetenv {
-                    query_pairs.append_pair(
-                        "unsetenv",
-                        &unsetenv
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(unsetlabel) = params.unsetlabel {
-                    query_pairs.append_pair(
-                        "unsetlabel",
-                        &unsetlabel
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-                if let Some(volume) = params.volume {
-                    query_pairs.append_pair(
-                        "volume",
-                        &volume
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /libpod/images/{name}
     /// Remove an image from the local storage.
@@ -170,27 +152,29 @@ pub trait Images: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/images/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/changes
     /// Report on changes to images's filesystem; adds, deletes or modifications.
@@ -204,30 +188,32 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageChangesLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/changes");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(parent) = params.parent {
-                    query_pairs.append_pair("parent", parent);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(diff_type) = params.diff_type {
-                    query_pairs.append_pair("diffType", diff_type);
+                request_path.push_str("/libpod/images/{name}/changes");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(parent) = params.parent {
+                        query_pairs.append_pair("parent", parent);
+                    }
+                    if let Some(diff_type) = params.diff_type {
+                        query_pairs.append_pair("diffType", diff_type);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/exists
     /// Image exists
@@ -236,21 +222,23 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/images/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/get
     /// Export an image
@@ -260,30 +248,32 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageGetLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/get");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(format) = params.format {
-                    query_pairs.append_pair("format", format);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(compress) = params.compress {
-                    query_pairs.append_pair("compress", &compress.to_string());
+                request_path.push_str("/libpod/images/{name}/get");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(format) = params.format {
+                        query_pairs.append_pair("format", format);
+                    }
+                    if let Some(compress) = params.compress {
+                        query_pairs.append_pair("compress", &compress.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/history
     /// History of an image
@@ -294,21 +284,23 @@ pub trait Images: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::HistoryResponse, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/history");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/images/{name}/history");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/json
     /// Inspect an image
@@ -318,21 +310,23 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::ImageData, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/images/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/{name}/push
     /// Push Image
@@ -342,42 +336,44 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImagePushLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/push");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(destination) = params.destination {
-                    query_pairs.append_pair("destination", destination);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(force_compression_format) = params.force_compression_format {
-                    query_pairs.append_pair(
-                        "forceCompressionFormat",
-                        &force_compression_format.to_string(),
-                    );
+                request_path.push_str("/libpod/images/{name}/push");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(destination) = params.destination {
+                        query_pairs.append_pair("destination", destination);
+                    }
+                    if let Some(force_compression_format) = params.force_compression_format {
+                        query_pairs.append_pair(
+                            "forceCompressionFormat",
+                            &force_compression_format.to_string(),
+                        );
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(quiet) = params.quiet {
+                        query_pairs.append_pair("quiet", &quiet.to_string());
+                    }
+                    if let Some(x_registry_auth) = params.x_registry_auth {
+                        req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
+                    }
                 }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(quiet) = params.quiet {
-                    query_pairs.append_pair("quiet", &quiet.to_string());
-                }
-                if let Some(x_registry_auth) = params.x_registry_auth {
-                    req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/resolve
     /// Resolve an image (short) name
@@ -386,21 +382,23 @@ pub trait Images: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/resolve");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/images/{name}/resolve");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/{name}/tag
     /// Tag an image
@@ -410,30 +408,32 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageTagLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/tag");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
+                request_path.push_str("/libpod/images/{name}/tag");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/{name}/tree
     /// Image tree
@@ -445,27 +445,29 @@ pub trait Images: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::ImageTreeReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/tree");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(whatrequires) = params.whatrequires {
-                    query_pairs.append_pair("whatrequires", &whatrequires.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/images/{name}/tree");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(whatrequires) = params.whatrequires {
+                        query_pairs.append_pair("whatrequires", &whatrequires.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/{name}/untag
     /// Untag an image
@@ -475,30 +477,32 @@ pub trait Images: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageUntagLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/{name}/untag");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
+                request_path.push_str("/libpod/images/{name}/untag");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/export
     /// Export multiple images
@@ -506,47 +510,45 @@ pub trait Images: HasConfig + Send + Sync {
     fn image_export_libpod<'a>(
         &'a self,
         params: Option<super::super::params::ImageExportLibpod<'a>>,
-    ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/export");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(format) = params.format {
-                    query_pairs.append_pair("format", format);
+    ) -> Pin<Box<dyn futures::stream::Stream<Item = Result<bytes::Bytes, Error>> + 'a>> {
+        request::execute_request_stream(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(references) = params.references {
-                    query_pairs.append_pair(
-                        "references",
-                        &references
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+                request_path.push_str("/libpod/images/export");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(format) = params.format {
+                        query_pairs.append_pair("format", format);
+                    }
+                    if let Some(references) = params.references {
+                        for value in references {
+                            query_pairs.append_pair("references", &value.to_string());
+                        }
+                    }
+                    if let Some(compress) = params.compress {
+                        query_pairs.append_pair("compress", &compress.to_string());
+                    }
+                    if let Some(oci_accept_uncompressed_layers) =
+                        params.oci_accept_uncompressed_layers
+                    {
+                        query_pairs.append_pair(
+                            "ociAcceptUncompressedLayers",
+                            &oci_accept_uncompressed_layers.to_string(),
+                        );
+                    }
                 }
-                if let Some(compress) = params.compress {
-                    query_pairs.append_pair("compress", &compress.to_string());
-                }
-                if let Some(oci_accept_uncompressed_layers) = params.oci_accept_uncompressed_layers
-                {
-                    query_pairs.append_pair(
-                        "ociAcceptUncompressedLayers",
-                        &oci_accept_uncompressed_layers.to_string(),
-                    );
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        )
     }
     /// POST /libpod/images/import
     /// Import image
@@ -560,48 +562,45 @@ pub trait Images: HasConfig + Send + Sync {
             dyn Future<Output = Result<super::super::models::ImageImportReport, Error>> + Send + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/import");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(changes) = params.changes {
-                    query_pairs.append_pair(
-                        "changes",
-                        &changes
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(message) = params.message {
-                    query_pairs.append_pair("message", message);
+                request_path.push_str("/libpod/images/import");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(changes) = params.changes {
+                        for value in changes {
+                            query_pairs.append_pair("changes", &value.to_string());
+                        }
+                    }
+                    if let Some(message) = params.message {
+                        query_pairs.append_pair("message", message);
+                    }
+                    if let Some(reference) = params.reference {
+                        query_pairs.append_pair("reference", reference);
+                    }
+                    if let Some(url) = params.url {
+                        query_pairs.append_pair("url", url);
+                    }
+                    if let Some(content_type) = params.content_type {
+                        req_builder = req_builder.header("Content-Type", content_type);
+                    }
                 }
-                if let Some(reference) = params.reference {
-                    query_pairs.append_pair("reference", reference);
-                }
-                if let Some(url) = params.url {
-                    query_pairs.append_pair("url", url);
-                }
-                if let Some(content_type) = params.content_type {
-                    req_builder = req_builder.header("Content-Type", content_type);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&upload)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&upload)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/images/json
     /// List Images
@@ -616,29 +615,31 @@ pub trait Images: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+                request_path.push_str("/libpod/images/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/load
     /// Load image
@@ -649,23 +650,25 @@ pub trait Images: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::ImageLoadReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/load");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&upload)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/images/load");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&upload)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/images/prune
     /// Prune unused images
@@ -676,32 +679,34 @@ pub trait Images: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<Vec<super::super::models::PruneReport>, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(external) = params.external {
-                    query_pairs.append_pair("external", &external.to_string());
+                request_path.push_str("/libpod/images/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(external) = params.external {
+                        query_pairs.append_pair("external", &external.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/pull
     /// Pull images
@@ -716,53 +721,55 @@ pub trait Images: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/pull");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(reference) = params.reference {
-                    query_pairs.append_pair("reference", reference);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(quiet) = params.quiet.or(Some(true)) {
-                    query_pairs.append_pair("quiet", &quiet.to_string());
+                request_path.push_str("/libpod/images/pull");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(reference) = params.reference {
+                        query_pairs.append_pair("reference", reference);
+                    }
+                    if let Some(quiet) = params.quiet.or(Some(true)) {
+                        query_pairs.append_pair("quiet", &quiet.to_string());
+                    }
+                    if let Some(compat_mode) = params.compat_mode {
+                        query_pairs.append_pair("compatMode", &compat_mode.to_string());
+                    }
+                    if let Some(arch) = params.arch {
+                        query_pairs.append_pair("Arch", arch);
+                    }
+                    if let Some(os) = params.os {
+                        query_pairs.append_pair("OS", os);
+                    }
+                    if let Some(variant) = params.variant {
+                        query_pairs.append_pair("Variant", variant);
+                    }
+                    if let Some(policy) = params.policy {
+                        query_pairs.append_pair("policy", policy);
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(all_tags) = params.all_tags {
+                        query_pairs.append_pair("allTags", &all_tags.to_string());
+                    }
+                    if let Some(x_registry_auth) = params.x_registry_auth {
+                        req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
+                    }
                 }
-                if let Some(compat_mode) = params.compat_mode {
-                    query_pairs.append_pair("compatMode", &compat_mode.to_string());
-                }
-                if let Some(arch) = params.arch {
-                    query_pairs.append_pair("Arch", arch);
-                }
-                if let Some(os) = params.os {
-                    query_pairs.append_pair("OS", os);
-                }
-                if let Some(variant) = params.variant {
-                    query_pairs.append_pair("Variant", variant);
-                }
-                if let Some(policy) = params.policy {
-                    query_pairs.append_pair("policy", policy);
-                }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(all_tags) = params.all_tags {
-                    query_pairs.append_pair("allTags", &all_tags.to_string());
-                }
-                if let Some(x_registry_auth) = params.x_registry_auth {
-                    req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /libpod/images/remove
     /// Remove one or more images from the storage.
@@ -777,45 +784,42 @@ pub trait Images: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/remove");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(images) = params.images {
-                    query_pairs.append_pair(
-                        "images",
-                        &images
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+                request_path.push_str("/libpod/images/remove");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(images) = params.images {
+                        for value in images {
+                            query_pairs.append_pair("images", &value.to_string());
+                        }
+                    }
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                    if let Some(ignore) = params.ignore {
+                        query_pairs.append_pair("ignore", &ignore.to_string());
+                    }
+                    if let Some(lookup_manifest) = params.lookup_manifest {
+                        query_pairs.append_pair("lookupManifest", &lookup_manifest.to_string());
+                    }
                 }
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
-                }
-                if let Some(ignore) = params.ignore {
-                    query_pairs.append_pair("ignore", &ignore.to_string());
-                }
-                if let Some(lookup_manifest) = params.lookup_manifest {
-                    query_pairs.append_pair("lookupManifest", &lookup_manifest.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/images/scp/{name}
     /// Copy an image from one host to another
@@ -826,30 +830,32 @@ pub trait Images: HasConfig + Send + Sync {
         params: Option<super::super::params::ImageScpLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::ScpReport, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/scp/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(destination) = params.destination {
-                    query_pairs.append_pair("destination", destination);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(quiet) = params.quiet.or(Some(true)) {
-                    query_pairs.append_pair("quiet", &quiet.to_string());
+                request_path.push_str("/libpod/images/scp/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(destination) = params.destination {
+                        query_pairs.append_pair("destination", destination);
+                    }
+                    if let Some(quiet) = params.quiet.or(Some(true)) {
+                        query_pairs.append_pair("quiet", &quiet.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/images/search
     /// Search images
@@ -864,37 +870,39 @@ pub trait Images: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/images/search");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(term) = params.term {
-                    query_pairs.append_pair("term", term);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(limit) = params.limit {
-                    query_pairs.append_pair("limit", &limit.to_string());
+                request_path.push_str("/libpod/images/search");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(term) = params.term {
+                        query_pairs.append_pair("term", term);
+                    }
+                    if let Some(limit) = params.limit {
+                        query_pairs.append_pair("limit", &limit.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(list_tags) = params.list_tags {
+                        query_pairs.append_pair("listTags", &list_tags.to_string());
+                    }
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(list_tags) = params.list_tags {
-                    query_pairs.append_pair("listTags", &list_tags.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/images_compat.rs
+++ b/src/v5/apis/images_compat.rs
@@ -13,104 +13,106 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         input_stream: String,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::ImageBuild200, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/build");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(dockerfile) = params.dockerfile {
-                    query_pairs.append_pair("dockerfile", dockerfile);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", t);
+                request_path.push_str("/build");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(dockerfile) = params.dockerfile {
+                        query_pairs.append_pair("dockerfile", dockerfile);
+                    }
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", t);
+                    }
+                    if let Some(extrahosts) = params.extrahosts {
+                        query_pairs.append_pair("extrahosts", extrahosts);
+                    }
+                    if let Some(remote) = params.remote {
+                        query_pairs.append_pair("remote", remote);
+                    }
+                    if let Some(q) = params.q {
+                        query_pairs.append_pair("q", &q.to_string());
+                    }
+                    if let Some(nocache) = params.nocache {
+                        query_pairs.append_pair("nocache", &nocache.to_string());
+                    }
+                    if let Some(cachefrom) = params.cachefrom {
+                        query_pairs.append_pair("cachefrom", cachefrom);
+                    }
+                    if let Some(pull) = params.pull {
+                        query_pairs.append_pair("pull", &pull.to_string());
+                    }
+                    if let Some(rm) = params.rm {
+                        query_pairs.append_pair("rm", &rm.to_string());
+                    }
+                    if let Some(forcerm) = params.forcerm {
+                        query_pairs.append_pair("forcerm", &forcerm.to_string());
+                    }
+                    if let Some(memory) = params.memory {
+                        query_pairs.append_pair("memory", &memory.to_string());
+                    }
+                    if let Some(memswap) = params.memswap {
+                        query_pairs.append_pair("memswap", &memswap.to_string());
+                    }
+                    if let Some(cpushares) = params.cpushares {
+                        query_pairs.append_pair("cpushares", &cpushares.to_string());
+                    }
+                    if let Some(cpusetcpus) = params.cpusetcpus {
+                        query_pairs.append_pair("cpusetcpus", cpusetcpus);
+                    }
+                    if let Some(cpuperiod) = params.cpuperiod {
+                        query_pairs.append_pair("cpuperiod", &cpuperiod.to_string());
+                    }
+                    if let Some(cpuquota) = params.cpuquota {
+                        query_pairs.append_pair("cpuquota", &cpuquota.to_string());
+                    }
+                    if let Some(buildargs) = params.buildargs {
+                        query_pairs.append_pair("buildargs", buildargs);
+                    }
+                    if let Some(shmsize) = params.shmsize {
+                        query_pairs.append_pair("shmsize", &shmsize.to_string());
+                    }
+                    if let Some(squash) = params.squash {
+                        query_pairs.append_pair("squash", &squash.to_string());
+                    }
+                    if let Some(labels) = params.labels {
+                        query_pairs.append_pair("labels", labels);
+                    }
+                    if let Some(networkmode) = params.networkmode {
+                        query_pairs.append_pair("networkmode", networkmode);
+                    }
+                    if let Some(platform) = params.platform {
+                        query_pairs.append_pair("platform", platform);
+                    }
+                    if let Some(target) = params.target {
+                        query_pairs.append_pair("target", target);
+                    }
+                    if let Some(outputs) = params.outputs {
+                        query_pairs.append_pair("outputs", outputs);
+                    }
+                    if let Some(content_type) = params.content_type {
+                        req_builder = req_builder.header("Content-Type", content_type);
+                    }
+                    if let Some(x_registry_config) = params.x_registry_config {
+                        req_builder = req_builder.header("X-Registry-Config", x_registry_config);
+                    }
                 }
-                if let Some(extrahosts) = params.extrahosts {
-                    query_pairs.append_pair("extrahosts", extrahosts);
-                }
-                if let Some(remote) = params.remote {
-                    query_pairs.append_pair("remote", remote);
-                }
-                if let Some(q) = params.q {
-                    query_pairs.append_pair("q", &q.to_string());
-                }
-                if let Some(nocache) = params.nocache {
-                    query_pairs.append_pair("nocache", &nocache.to_string());
-                }
-                if let Some(cachefrom) = params.cachefrom {
-                    query_pairs.append_pair("cachefrom", cachefrom);
-                }
-                if let Some(pull) = params.pull {
-                    query_pairs.append_pair("pull", &pull.to_string());
-                }
-                if let Some(rm) = params.rm {
-                    query_pairs.append_pair("rm", &rm.to_string());
-                }
-                if let Some(forcerm) = params.forcerm {
-                    query_pairs.append_pair("forcerm", &forcerm.to_string());
-                }
-                if let Some(memory) = params.memory {
-                    query_pairs.append_pair("memory", &memory.to_string());
-                }
-                if let Some(memswap) = params.memswap {
-                    query_pairs.append_pair("memswap", &memswap.to_string());
-                }
-                if let Some(cpushares) = params.cpushares {
-                    query_pairs.append_pair("cpushares", &cpushares.to_string());
-                }
-                if let Some(cpusetcpus) = params.cpusetcpus {
-                    query_pairs.append_pair("cpusetcpus", cpusetcpus);
-                }
-                if let Some(cpuperiod) = params.cpuperiod {
-                    query_pairs.append_pair("cpuperiod", &cpuperiod.to_string());
-                }
-                if let Some(cpuquota) = params.cpuquota {
-                    query_pairs.append_pair("cpuquota", &cpuquota.to_string());
-                }
-                if let Some(buildargs) = params.buildargs {
-                    query_pairs.append_pair("buildargs", buildargs);
-                }
-                if let Some(shmsize) = params.shmsize {
-                    query_pairs.append_pair("shmsize", &shmsize.to_string());
-                }
-                if let Some(squash) = params.squash {
-                    query_pairs.append_pair("squash", &squash.to_string());
-                }
-                if let Some(labels) = params.labels {
-                    query_pairs.append_pair("labels", labels);
-                }
-                if let Some(networkmode) = params.networkmode {
-                    query_pairs.append_pair("networkmode", networkmode);
-                }
-                if let Some(platform) = params.platform {
-                    query_pairs.append_pair("platform", platform);
-                }
-                if let Some(target) = params.target {
-                    query_pairs.append_pair("target", target);
-                }
-                if let Some(outputs) = params.outputs {
-                    query_pairs.append_pair("outputs", outputs);
-                }
-                if let Some(content_type) = params.content_type {
-                    req_builder = req_builder.header("Content-Type", content_type);
-                }
-                if let Some(x_registry_config) = params.x_registry_config {
-                    req_builder = req_builder.header("X-Registry-Config", x_registry_config);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&input_stream)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&input_stream)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// DELETE /images/{name}
     /// Remove Image
@@ -126,30 +128,32 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(noprune) = params.noprune {
-                    query_pairs.append_pair("noprune", &noprune.to_string());
+                request_path.push_str("/images/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                    if let Some(noprune) = params.noprune {
+                        query_pairs.append_pair("noprune", &noprune.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /images/{name}/get
     /// Export an image
@@ -158,21 +162,23 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}/get");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/images/{name}/get");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /images/{name}/history
     /// History of an image
@@ -183,21 +189,23 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::HistoryResponse, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}/history");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/images/{name}/history");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /images/{name}/json
     /// Inspect an image
@@ -207,21 +215,23 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::ImageInspect, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/images/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /images/{name}/push
     /// Push Image
@@ -231,39 +241,41 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImagePush<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}/push");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+                request_path.push_str("/images/{name}/push");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(compress) = params.compress {
+                        query_pairs.append_pair("compress", &compress.to_string());
+                    }
+                    if let Some(destination) = params.destination {
+                        query_pairs.append_pair("destination", destination);
+                    }
+                    if let Some(x_registry_auth) = params.x_registry_auth {
+                        req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
+                    }
                 }
-                if let Some(compress) = params.compress {
-                    query_pairs.append_pair("compress", &compress.to_string());
-                }
-                if let Some(destination) = params.destination {
-                    query_pairs.append_pair("destination", destination);
-                }
-                if let Some(x_registry_auth) = params.x_registry_auth {
-                    req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /images/{name}/tag
     /// Tag an image
@@ -273,30 +285,32 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::ImageTag<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/{name}/tag");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
+                request_path.push_str("/images/{name}/tag");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /images/create
     /// Create an image
@@ -306,47 +320,49 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         params: Option<super::super::params::ImageCreate<'a>>,
         input_image: String,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(from_image) = params.from_image {
-                    query_pairs.append_pair("fromImage", from_image);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(from_src) = params.from_src {
-                    query_pairs.append_pair("fromSrc", from_src);
+                request_path.push_str("/images/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(from_image) = params.from_image {
+                        query_pairs.append_pair("fromImage", from_image);
+                    }
+                    if let Some(from_src) = params.from_src {
+                        query_pairs.append_pair("fromSrc", from_src);
+                    }
+                    if let Some(repo) = params.repo {
+                        query_pairs.append_pair("repo", repo);
+                    }
+                    if let Some(tag) = params.tag {
+                        query_pairs.append_pair("tag", tag);
+                    }
+                    if let Some(message) = params.message {
+                        query_pairs.append_pair("message", message);
+                    }
+                    if let Some(platform) = params.platform {
+                        query_pairs.append_pair("platform", platform);
+                    }
+                    if let Some(x_registry_auth) = params.x_registry_auth {
+                        req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
+                    }
                 }
-                if let Some(repo) = params.repo {
-                    query_pairs.append_pair("repo", repo);
-                }
-                if let Some(tag) = params.tag {
-                    query_pairs.append_pair("tag", tag);
-                }
-                if let Some(message) = params.message {
-                    query_pairs.append_pair("message", message);
-                }
-                if let Some(platform) = params.platform {
-                    query_pairs.append_pair("platform", platform);
-                }
-                if let Some(x_registry_auth) = params.x_registry_auth {
-                    req_builder = req_builder.header("X-Registry-Auth", x_registry_auth);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&input_image)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&input_image)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /images/get
     /// Export several images
@@ -355,24 +371,26 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::ImageGetAll<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/get");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("names", params.names);
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/images/get");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("names", params.names);
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /images/json
     /// List Images
@@ -382,32 +400,34 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         params: Option<super::super::params::ImageList<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<super::super::models::Summary>, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+                request_path.push_str("/images/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                    if let Some(digests) = params.digests {
+                        query_pairs.append_pair("digests", &digests.to_string());
+                    }
                 }
-                if let Some(digests) = params.digests {
-                    query_pairs.append_pair("digests", &digests.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /images/load
     /// Import image
@@ -417,29 +437,31 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
         params: Option<super::super::params::ImageLoad>,
         request: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/load");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(quiet) = params.quiet {
-                    query_pairs.append_pair("quiet", &quiet.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/images/load");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(quiet) = params.quiet {
+                        query_pairs.append_pair("quiet", &quiet.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /images/prune
     /// Prune unused images
@@ -454,26 +476,28 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/images/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /images/search
     /// Search images
@@ -488,37 +512,39 @@ pub trait ImagesCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/images/search");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(term) = params.term {
-                    query_pairs.append_pair("term", term);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(limit) = params.limit {
-                    query_pairs.append_pair("limit", &limit.to_string());
+                request_path.push_str("/images/search");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(term) = params.term {
+                        query_pairs.append_pair("term", term);
+                    }
+                    if let Some(limit) = params.limit {
+                        query_pairs.append_pair("limit", &limit.to_string());
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(list_tags) = params.list_tags {
+                        query_pairs.append_pair("listTags", &list_tags.to_string());
+                    }
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(list_tags) = params.list_tags {
-                    query_pairs.append_pair("listTags", &list_tags.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/manifests.rs
+++ b/src/v5/apis/manifests.rs
@@ -19,21 +19,23 @@ pub trait Manifests: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/manifests/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/manifests/{name}
     /// Create
@@ -45,34 +47,36 @@ pub trait Manifests: HasConfig + Send + Sync {
         options: super::super::models::ManifestModifyOptions,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::IdResponse, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("images", params.images);
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(amend) = params.amend {
-                    query_pairs.append_pair("amend", &amend.to_string());
+                request_path.push_str("/libpod/manifests/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("images", params.images);
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(amend) = params.amend {
+                        query_pairs.append_pair("amend", &amend.to_string());
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&options)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&options)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/manifests/{name}
     /// Modify manifest list
@@ -93,30 +97,32 @@ pub trait Manifests: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&options)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/manifests/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&options)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/manifests/{name}/add
     /// Add image
@@ -129,24 +135,26 @@ pub trait Manifests: HasConfig + Send + Sync {
         options: super::super::models::ManifestAddOptions,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::IdResponse, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}/add");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&options)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/manifests/{name}/add");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&options)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/manifests/{name}/exists
     /// Exists
@@ -157,21 +165,23 @@ pub trait Manifests: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/manifests/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/manifests/{name}/json
     /// Inspect
@@ -185,27 +195,29 @@ pub trait Manifests: HasConfig + Send + Sync {
             dyn Future<Output = Result<super::super::models::Schema2ListPublic, Error>> + Send + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/manifests/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/manifests/{name}/push
     /// Push manifest to registry
@@ -218,28 +230,30 @@ pub trait Manifests: HasConfig + Send + Sync {
         params: Option<super::super::params::ManifestPushV3Libpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::IdResponse, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}/push");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("destination", params.destination);
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/manifests/{name}/push");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("destination", params.destination);
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/manifests/{name}/registry/{destination}
     /// Push manifest list to registry
@@ -253,49 +267,46 @@ pub trait Manifests: HasConfig + Send + Sync {
         params: Option<super::super::params::ManifestPushLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::IdResponse, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/manifests/{name}/registry/{destination}");
-            request_path = request_path.replace("{name}", name);
-            request_path = request_path.replace("{destination}", destination);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(add_compression) = params.add_compression {
-                    query_pairs.append_pair(
-                        "addCompression",
-                        &add_compression
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(force_compression_format) = params.force_compression_format {
-                    query_pairs.append_pair(
-                        "forceCompressionFormat",
-                        &force_compression_format.to_string(),
-                    );
+                request_path.push_str("/libpod/manifests/{name}/registry/{destination}");
+                request_path = request_path.replace("{name}", name);
+                request_path = request_path.replace("{destination}", destination);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(add_compression) = params.add_compression {
+                        for value in add_compression {
+                            query_pairs.append_pair("addCompression", &value.to_string());
+                        }
+                    }
+                    if let Some(force_compression_format) = params.force_compression_format {
+                        query_pairs.append_pair(
+                            "forceCompressionFormat",
+                            &force_compression_format.to_string(),
+                        );
+                    }
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(tls_verify) = params.tls_verify {
+                        query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
+                    }
+                    if let Some(quiet) = params.quiet {
+                        query_pairs.append_pair("quiet", &quiet.to_string());
+                    }
                 }
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
-                }
-                if let Some(tls_verify) = params.tls_verify {
-                    query_pairs.append_pair("tlsVerify", &tls_verify.to_string());
-                }
-                if let Some(quiet) = params.quiet {
-                    query_pairs.append_pair("quiet", &quiet.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/networks.rs
+++ b/src/v5/apis/networks.rs
@@ -18,27 +18,29 @@ pub trait Networks: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/networks/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/networks/{name}/connect
     /// Connect container to network
@@ -48,24 +50,26 @@ pub trait Networks: HasConfig + Send + Sync {
         name: &'a str,
         create: super::super::models::NetworkConnectOptions,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}/connect");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/{name}/connect");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/networks/{name}/disconnect
     /// Disconnect container from network
@@ -75,24 +79,26 @@ pub trait Networks: HasConfig + Send + Sync {
         name: &'a str,
         create: super::super::models::NetworkDisconnect,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}/disconnect");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/{name}/disconnect");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/networks/{name}/exists
     /// Network exists
@@ -101,21 +107,23 @@ pub trait Networks: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/networks/{name}/json
     /// Inspect a network
@@ -130,21 +138,23 @@ pub trait Networks: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/networks/{name}/update
     /// Update existing podman network
@@ -154,24 +164,26 @@ pub trait Networks: HasConfig + Send + Sync {
         name: &'a str,
         update: super::super::models::NetworkUpdateOptions,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/{name}/update");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&update)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/{name}/update");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&update)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /libpod/networks/create
     /// Create network
@@ -181,23 +193,25 @@ pub trait Networks: HasConfig + Send + Sync {
         create: super::super::models::NetworkCreateLibpod,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::Network, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/networks/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/networks/json
     /// List networks
@@ -208,26 +222,28 @@ pub trait Networks: HasConfig + Send + Sync {
         params: Option<super::super::params::NetworkListLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<super::super::models::Network>, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/networks/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/networks/prune
     /// Delete unused networks
@@ -242,25 +258,27 @@ pub trait Networks: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/networks/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/networks/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/networks_compat.rs
+++ b/src/v5/apis/networks_compat.rs
@@ -17,26 +17,28 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/networks");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /networks/{name}
     /// Remove a network
@@ -45,21 +47,23 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/networks/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /networks/{name}
     /// Inspect a network
@@ -71,30 +75,32 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::NetworkResource, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(verbose) = params.verbose {
-                    query_pairs.append_pair("verbose", &verbose.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(scope) = params.scope {
-                    query_pairs.append_pair("scope", scope);
+                request_path.push_str("/networks/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(verbose) = params.verbose {
+                        query_pairs.append_pair("verbose", &verbose.to_string());
+                    }
+                    if let Some(scope) = params.scope {
+                        query_pairs.append_pair("scope", scope);
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /networks/{name}/connect
     /// Connect container to network
@@ -104,24 +110,26 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
         name: &'a str,
         create: super::super::models::NetworkConnect,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/{name}/connect");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/networks/{name}/connect");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /networks/{name}/disconnect
     /// Disconnect container from network
@@ -131,24 +139,26 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
         name: &'a str,
         create: super::super::models::NetworkDisconnect,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/{name}/disconnect");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/networks/{name}/disconnect");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /networks/create
     /// Create network
@@ -159,23 +169,25 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::NetworkCreate201, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/networks/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /networks/prune
     /// Delete unused networks
@@ -186,25 +198,27 @@ pub trait NetworksCompat: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::NetworkPrune200, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/networks/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/networks/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/pods.rs
+++ b/src/v5/apis/pods.rs
@@ -12,27 +12,29 @@ pub trait Pods: HasConfig + Send + Sync {
         params: Option<super::super::params::PodDeleteLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::PodRmReport, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/pods/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/pods/{name}/exists
     /// Pod exists
@@ -41,21 +43,23 @@ pub trait Pods: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/pods/{name}/json
     /// Inspect pod
@@ -65,21 +69,23 @@ pub trait Pods: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::InspectPodData, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/kill
     /// Kill a pod
@@ -89,27 +95,29 @@ pub trait Pods: HasConfig + Send + Sync {
         params: Option<super::super::params::PodKillLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::PodKillReport, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/kill");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(signal) = params.signal {
-                    query_pairs.append_pair("signal", signal);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/pods/{name}/kill");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(signal) = params.signal {
+                        query_pairs.append_pair("signal", signal);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/pause
     /// Pause a pod
@@ -120,21 +128,23 @@ pub trait Pods: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::PodPauseReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/pause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/pause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/restart
     /// Restart a pod
@@ -144,21 +154,23 @@ pub trait Pods: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::PodRestartReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/restart");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/restart");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/start
     /// Start a pod
@@ -168,21 +180,23 @@ pub trait Pods: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::PodStartReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/start");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/start");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/stop
     /// Stop a pod
@@ -192,27 +206,29 @@ pub trait Pods: HasConfig + Send + Sync {
         params: Option<super::super::params::PodStopLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::PodStopReport, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/stop");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(t) = params.t {
-                    query_pairs.append_pair("t", &t.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/pods/{name}/stop");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(t) = params.t {
+                        query_pairs.append_pair("t", &t.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/pods/{name}/top
     /// List processes
@@ -223,33 +239,35 @@ pub trait Pods: HasConfig + Send + Sync {
         params: Option<super::super::params::PodTopLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::PodTopOkBody, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/top");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(delay) = params.delay {
-                    query_pairs.append_pair("delay", &delay.to_string());
+                request_path.push_str("/libpod/pods/{name}/top");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
+                    if let Some(delay) = params.delay {
+                        query_pairs.append_pair("delay", &delay.to_string());
+                    }
+                    if let Some(ps_args) = params.ps_args {
+                        query_pairs.append_pair("ps_args", ps_args);
+                    }
                 }
-                if let Some(ps_args) = params.ps_args {
-                    query_pairs.append_pair("ps_args", ps_args);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/{name}/unpause
     /// Unpause a pod
@@ -259,21 +277,23 @@ pub trait Pods: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::PodUnpauseReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/{name}/unpause");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/{name}/unpause");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/create
     /// Create a pod
@@ -282,23 +302,25 @@ pub trait Pods: HasConfig + Send + Sync {
         create: super::super::models::PodSpecGenerator,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::IdResponse, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/pods/json
     /// List pods
@@ -312,26 +334,28 @@ pub trait Pods: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/pods/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/pods/prune
     /// Prune unused pods
@@ -340,20 +364,22 @@ pub trait Pods: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::PodPruneReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/pods/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/pods/stats
     /// Statistics for one or more pods
@@ -368,35 +394,32 @@ pub trait Pods: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/pods/stats");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(names_or_i_ds) = params.names_or_i_ds {
-                    query_pairs.append_pair(
-                        "namesOrIDs",
-                        &names_or_i_ds
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                    );
+                request_path.push_str("/libpod/pods/stats");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                    if let Some(names_or_i_ds) = params.names_or_i_ds {
+                        for value in names_or_i_ds {
+                            query_pairs.append_pair("namesOrIDs", &value.to_string());
+                        }
+                    }
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/secrets.rs
+++ b/src/v5/apis/secrets.rs
@@ -11,27 +11,29 @@ pub trait Secrets: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::SecretDeleteLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/secrets/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(all) = params.all {
-                    query_pairs.append_pair("all", &all.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/secrets/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(all) = params.all {
+                        query_pairs.append_pair("all", &all.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/secrets/{name}/exists
     /// Secret exists
@@ -39,21 +41,23 @@ pub trait Secrets: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/secrets/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/secrets/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/secrets/{name}/json
     /// Inspect secret
@@ -64,27 +68,29 @@ pub trait Secrets: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::SecretInfoReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/secrets/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(showsecret) = params.showsecret {
-                    query_pairs.append_pair("showsecret", &showsecret.to_string());
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/secrets/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(showsecret) = params.showsecret {
+                        query_pairs.append_pair("showsecret", &showsecret.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/secrets/create
     /// Create a secret
@@ -99,36 +105,38 @@ pub trait Secrets: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/secrets/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                query_pairs.append_pair("name", params.name);
-                if let Some(driver) = params.driver {
-                    query_pairs.append_pair("driver", driver);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(driveropts) = params.driveropts {
-                    query_pairs.append_pair("driveropts", driveropts);
+                request_path.push_str("/libpod/secrets/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    query_pairs.append_pair("name", params.name);
+                    if let Some(driver) = params.driver {
+                        query_pairs.append_pair("driver", driver);
+                    }
+                    if let Some(driveropts) = params.driveropts {
+                        query_pairs.append_pair("driveropts", driveropts);
+                    }
+                    if let Some(labels) = params.labels {
+                        query_pairs.append_pair("labels", labels);
+                    }
                 }
-                if let Some(labels) = params.labels {
-                    query_pairs.append_pair("labels", labels);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&request)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&request)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/secrets/json
     /// List secrets
@@ -143,25 +151,27 @@ pub trait Secrets: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/secrets/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/secrets/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/secrets_compat.rs
+++ b/src/v5/apis/secrets_compat.rs
@@ -17,26 +17,28 @@ pub trait SecretsCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/secrets");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/secrets");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /secrets/{name}
     /// Remove secret
@@ -44,21 +46,23 @@ pub trait SecretsCompat: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/secrets/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/secrets/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /secrets/{name}
     /// Inspect secret
@@ -72,21 +76,23 @@ pub trait SecretsCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/secrets/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/secrets/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /secrets/create
     /// Create a secret
@@ -100,22 +106,24 @@ pub trait SecretsCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/secrets/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/secrets/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/system.rs
+++ b/src/v5/apis/system.rs
@@ -11,35 +11,37 @@ pub trait System: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::SystemEventsLibpod<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/events");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(since) = params.since {
-                    query_pairs.append_pair("since", since);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(until) = params.until {
-                    query_pairs.append_pair("until", until);
+                request_path.push_str("/libpod/events");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(since) = params.since {
+                        query_pairs.append_pair("since", since);
+                    }
+                    if let Some(until) = params.until {
+                        query_pairs.append_pair("until", until);
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                    if let Some(stream) = params.stream {
+                        query_pairs.append_pair("stream", &stream.to_string());
+                    }
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-                if let Some(stream) = params.stream {
-                    query_pairs.append_pair("stream", &stream.to_string());
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/info
     /// Get info
@@ -48,20 +50,22 @@ pub trait System: HasConfig + Send + Sync {
         &'a self,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::LibpodInfo, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/info");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/info");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/system/df
     /// Show disk usage
@@ -71,20 +75,22 @@ pub trait System: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::SystemDfReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/system/df");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/system/df");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/system/prune
     /// Prune unused data
@@ -95,20 +101,22 @@ pub trait System: HasConfig + Send + Sync {
             dyn Future<Output = Result<super::super::models::SystemPruneReport, Error>> + Send + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/system/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/system/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/version
     /// Component Version information
@@ -121,19 +129,21 @@ pub trait System: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/version");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/version");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/system_compat.rs
+++ b/src/v5/apis/system_compat.rs
@@ -11,23 +11,25 @@ pub trait SystemCompat: HasConfig + Send + Sync {
         auth_config: super::super::models::AuthConfig,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::AuthReport, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/auth");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&auth_config)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/auth");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&auth_config)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /events
     /// Get events
@@ -36,51 +38,55 @@ pub trait SystemCompat: HasConfig + Send + Sync {
         &'a self,
         params: Option<super::super::params::SystemEvents<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/events");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(since) = params.since {
-                    query_pairs.append_pair("since", since);
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-                if let Some(until) = params.until {
-                    query_pairs.append_pair("until", until);
+                request_path.push_str("/events");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(since) = params.since {
+                        query_pairs.append_pair("since", since);
+                    }
+                    if let Some(until) = params.until {
+                        query_pairs.append_pair("until", until);
+                    }
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
                 }
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
-                }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /info
     /// Get info
     /// Returns information on the system and libpod configuration
     fn system_info<'a>(&'a self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/info");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/info");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/_ping
     /// Ping service
@@ -91,20 +97,22 @@ pub trait SystemCompat: HasConfig + Send + Sync {
     fn system_ping<'a>(
         &'a self,
     ) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/_ping");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/_ping");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /system/df
     /// Show disk usage
@@ -114,20 +122,22 @@ pub trait SystemCompat: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<super::super::models::SystemDfReport, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/system/df");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/system/df");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /version
     /// Component Version information
@@ -140,19 +150,21 @@ pub trait SystemCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/version");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/version");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/volumes.rs
+++ b/src/v5/apis/volumes.rs
@@ -11,27 +11,29 @@ pub trait Volumes: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::VolumeDeleteLibpod>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/volumes/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/volumes/{name}/exists
     /// Volume exists
@@ -40,21 +42,23 @@ pub trait Volumes: HasConfig + Send + Sync {
         &'a self,
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/{name}/exists");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/volumes/{name}/exists");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /libpod/volumes/{name}/json
     /// Inspect volume
@@ -68,21 +72,23 @@ pub trait Volumes: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/{name}/json");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/volumes/{name}/json");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/volumes/create
     /// Create a volume
@@ -96,23 +102,25 @@ pub trait Volumes: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/libpod/volumes/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// GET /libpod/volumes/json
     /// List volumes
@@ -127,26 +135,28 @@ pub trait Volumes: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/json");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/volumes/json");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /libpod/volumes/prune
     /// Prune volumes
@@ -156,25 +166,27 @@ pub trait Volumes: HasConfig + Send + Sync {
     ) -> Pin<
         Box<dyn Future<Output = Result<Vec<super::super::models::PruneReport>, Error>> + Send + 'a>,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/libpod/volumes/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/libpod/volumes/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/src/v5/apis/volumes_compat.rs
+++ b/src/v5/apis/volumes_compat.rs
@@ -12,26 +12,28 @@ pub trait VolumesCompat: HasConfig + Send + Sync {
         params: Option<super::super::params::VolumeList<'a>>,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::ListResponse, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/volumes");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/volumes");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// DELETE /volumes/{name}
     /// Remove volume
@@ -40,27 +42,29 @@ pub trait VolumesCompat: HasConfig + Send + Sync {
         name: &'a str,
         params: Option<super::super::params::VolumeDelete>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/volumes/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("DELETE")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(force) = params.force {
-                    query_pairs.append_pair("force", &force.to_string());
+        Box::pin(request::execute_request_unit(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_unit(self.get_config(), request).await
-        })
+                request_path.push_str("/volumes/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("DELETE")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(force) = params.force {
+                        query_pairs.append_pair("force", &force.to_string());
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// GET /volumes/{name}
     /// Inspect volume
@@ -69,21 +73,23 @@ pub trait VolumesCompat: HasConfig + Send + Sync {
         name: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::Volume, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/volumes/{name}");
-            request_path = request_path.replace("{name}", name);
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("GET")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/volumes/{name}");
+                request_path = request_path.replace("{name}", name);
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("GET")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
     /// POST /volumes/create
     /// Create a volume
@@ -92,23 +98,25 @@ pub trait VolumesCompat: HasConfig + Send + Sync {
         create: super::super::models::VolumeCreate,
     ) -> Pin<Box<dyn Future<Output = Result<super::super::models::Volume, Error>> + Send + 'a>>
     {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/volumes/create");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let body = serde_json::to_string(&create)?;
-            req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
-            req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
-            let request = req_builder.body(body)?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
+                }
+                request_path.push_str("/volumes/create");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                let body = serde_json::to_string(&create)?;
+                req_builder = req_builder.header(hyper::header::CONTENT_TYPE, "application/json");
+                req_builder = req_builder.header(hyper::header::CONTENT_LENGTH, body.len());
+                Ok(req_builder.body(body)?)
+            })(),
+        ))
     }
     /// POST /volumes/prune
     /// Prune volumes
@@ -122,25 +130,27 @@ pub trait VolumesCompat: HasConfig + Send + Sync {
                 + 'a,
         >,
     > {
-        Box::pin(async move {
-            let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
-            let mut request_path = request_url.path().to_owned();
-            if request_path.ends_with('/') {
-                request_path.pop();
-            }
-            request_path.push_str("/volumes/prune");
-            request_url.set_path(&request_path);
-            let mut req_builder = self.get_config().req_builder("POST")?;
-            if let Some(params) = params {
-                let mut query_pairs = request_url.query_pairs_mut();
-                if let Some(filters) = params.filters {
-                    query_pairs.append_pair("filters", filters);
+        Box::pin(request::execute_request_json(
+            self.get_config(),
+            (|| {
+                let mut request_url = url::Url::parse(self.get_config().get_base_path())?;
+                let mut request_path = request_url.path().to_owned();
+                if request_path.ends_with('/') {
+                    request_path.pop();
                 }
-            }
-            let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
-            req_builder = req_builder.uri(hyper_uri);
-            let request = req_builder.body(String::new())?;
-            request::execute_request_json(self.get_config(), request).await
-        })
+                request_path.push_str("/volumes/prune");
+                request_url.set_path(&request_path);
+                let mut req_builder = self.get_config().req_builder("POST")?;
+                if let Some(params) = params {
+                    let mut query_pairs = request_url.query_pairs_mut();
+                    if let Some(filters) = params.filters {
+                        query_pairs.append_pair("filters", filters);
+                    }
+                }
+                let hyper_uri: hyper::Uri = request_url.as_str().parse()?;
+                req_builder = req_builder.uri(hyper_uri);
+                Ok(req_builder.body(String::new())?)
+            })(),
+        ))
     }
 }

--- a/swagger/swagger-v5.1.0.modified.yaml
+++ b/swagger/swagger-v5.1.0.modified.yaml
@@ -13467,7 +13467,7 @@ paths:
                   required: true
                   type: string
             produces:
-                - application/json
+                - application/x-tar
             responses:
                 "200":
                     description: tarball is returned in body
@@ -14906,7 +14906,7 @@ paths:
                   name: ociAcceptUncompressedLayers
                   type: boolean
             produces:
-                - application/json
+                - application/x-tar
             responses:
                 "200":
                     description: no error

--- a/tests/v5.rs
+++ b/tests/v5.rs
@@ -276,7 +276,7 @@ async fn it_exports_images() {
         compress: None,
         format: Some("docker-archive"),
         oci_accept_uncompressed_layers: None,
-        references: Some(["nginx"].to_vec()),
+        references: Some(["nginx", "alpine"].to_vec()),
     };
     let stream = client.images().image_export_libpod(Some(params));
 

--- a/tests/v5_common.rs
+++ b/tests/v5_common.rs
@@ -55,6 +55,17 @@ pub async fn test_init() {
         .await;
 }
 
+pub async fn pull_alpine_image(client: &PodmanRestClient) {
+    client
+        .images()
+        .image_pull_libpod(Some(params::ImagePullLibpod {
+            reference: Some("docker.io/library/alpine:latest"),
+            ..Default::default()
+        }))
+        .await
+        .expect("Failed to pull image");
+}
+
 pub async fn pull_nginx_image(client: &PodmanRestClient) {
     client
         .images()


### PR DESCRIPTION
The image export request functions were not processing responses. We now return a stream of bytes for any endpoint marked as producing `application/x-tar` responses.